### PR TITLE
Base64 encoding expect binary data as input (not a string)

### DIFF
--- a/lib/isodoc/html_function/html.rb
+++ b/lib/isodoc/html_function/html.rb
@@ -259,7 +259,7 @@ module IsoDoc::HtmlFunction
 
     def datauri(i)
       type = i["src"].split(".")[-1]
-      bin = File.read(@localdir + i["src"], encoding: "utf-8")
+      bin = IO.binread(File.join(@localdir, i["src"]))
       data = Base64.strict_encode64(bin)
       i["src"] = "data:image/#{type};base64,#{data}"
     end


### PR DESCRIPTION
Related to:
 - https://github.com/metanorma/metanorma-nist/issues/126
 - https://github.com/metanorma/metanorma-ogc/issues/36