### PR TITLE
css files not being invoked

### DIFF
--- a/isodoc.gemspec
+++ b/isodoc.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "liquid"
   spec.add_dependency "roman-numerals"
   spec.add_dependency "metanorma", "~> 1.1.0"
-  spec.add_dependency "rake", "~> 12.0"
 
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "byebug", "~> 9.1"
   spec.add_development_dependency "sassc", "~> 2.4.0"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"

--- a/lib/isodoc/gem_tasks.rb
+++ b/lib/isodoc/gem_tasks.rb
@@ -33,8 +33,7 @@ module IsoDoc
         process_css_files(scss_files) do |file_name|
           uncomment_out_liquid(File.read(file_name, encoding: 'UTF-8'))
         end
-        git_cache_compiled_files
-        puts('Built scss!')
+        git_cache_compiled_files && puts('Built scss!')
       end
 
       Rake::Task['build'].enhance [:build_scss] do
@@ -92,7 +91,8 @@ module IsoDoc
 
     def compile_scss(filename)
       require 'sassc'
-      [File.join(Gem.loaded_specs['isodoc'].full_gem_path, 'lib', 'isodoc'),
+
+      [File.join('lib', 'isodoc'),
        File.dirname(filename)].each do |name|
         SassC.load_paths << name
       end

--- a/lib/isodoc/gem_tasks.rb
+++ b/lib/isodoc/gem_tasks.rb
@@ -16,7 +16,7 @@ module IsoDoc
           puts(current_task)
           compile_scss_task(current_task)
         rescue StandardError => e
-          puts(e.message, "skiping #{current_task}")
+          notify_borken_compilation(e, current_task)
         end
       end
 
@@ -39,6 +39,17 @@ module IsoDoc
       Rake::Task['build'].enhance [:build_scss] do
         git_rm_compiled_files
         Rake::Task[:clean].invoke
+      end
+    end
+
+    def notify_borken_compilation(error, current_task)
+      puts("Cannot compile #{current_task} because of #{error.message}")
+      puts('continue anyway[y|n]?')
+      answer = STDIN.gets.strip
+      if %w[y yes].include?(answer.strip.downcase)
+        puts("Cannot compile #{current_task} because of #{error.message}")
+      else
+        exit(0)
       end
     end
 

--- a/lib/isodoc/gem_tasks.rb
+++ b/lib/isodoc/gem_tasks.rb
@@ -34,10 +34,16 @@ module IsoDoc
         process_css_files(scss_files) do |file_name|
           uncomment_out_liquid(File.read(file_name, encoding: 'UTF-8'))
         end
+        CLEAN.each do |css_file|
+          sh "git add #{css_file}"
+        end
         puts('Built scss!')
       end
 
       Rake::Task['build'].enhance [:build_scss] do
+        CLEAN.each do |css_file|
+          sh "git rm --cached #{css_file}"
+        end
         Rake::Task[:clean].invoke
       end
     end

--- a/lib/isodoc/gem_tasks.rb
+++ b/lib/isodoc/gem_tasks.rb
@@ -92,7 +92,12 @@ module IsoDoc
     def compile_scss(filename)
       require 'sassc'
 
-      [File.join('lib', 'isodoc'),
+      isodoc_path = if Gem.loaded_specs['isodoc']
+                      File.join(Gem.loaded_specs['isodoc'].full_gem_path, 'lib', 'isodoc')
+                    else
+                      File.join('lib', 'isodoc')
+                    end
+      [isodoc_path,
        File.dirname(filename)].each do |name|
         SassC.load_paths << name
       end

--- a/lib/isodoc/gem_tasks.rb
+++ b/lib/isodoc/gem_tasks.rb
@@ -16,8 +16,7 @@ module IsoDoc
           puts(current_task)
           compile_scss_task(current_task)
         rescue StandardError => e
-          puts(e.message)
-          puts("skiping #{current_task}")
+          puts(e.message, "skiping #{current_task}")
         end
       end
 
@@ -34,17 +33,25 @@ module IsoDoc
         process_css_files(scss_files) do |file_name|
           uncomment_out_liquid(File.read(file_name, encoding: 'UTF-8'))
         end
-        CLEAN.each do |css_file|
-          sh "git add #{css_file}"
-        end
+        git_cache_compiled_files
         puts('Built scss!')
       end
 
       Rake::Task['build'].enhance [:build_scss] do
-        CLEAN.each do |css_file|
-          sh "git rm --cached #{css_file}"
-        end
+        git_rm_compiled_files
         Rake::Task[:clean].invoke
+      end
+    end
+
+    def git_cache_compiled_files
+      CLEAN.each do |css_file|
+        sh "git add #{css_file}"
+      end
+    end
+
+    def git_rm_compiled_files
+      CLEAN.each do |css_file|
+        sh "git rm --cached #{css_file}"
       end
     end
 

--- a/lib/isodoc/version.rb
+++ b/lib/isodoc/version.rb
@@ -1,3 +1,3 @@
 module IsoDoc
-  VERSION = "1.1.3-alpha2".freeze
+  VERSION = "1.1.3-alpha3".freeze
 end


### PR DESCRIPTION
metanorma/isodoc#195 cache compiled css files into the igt during build process, then unache them up during clean up