### PR TITLE
 pass font manifest as hash and remove quote (because this happens on mn2pdf side)

### DIFF
--- a/lib/isodoc/xslfo_convert.rb
+++ b/lib/isodoc/xslfo_convert.rb
@@ -3,7 +3,7 @@ require "metanorma"
 module IsoDoc
   class XslfoPdfConvert < ::IsoDoc::Convert
     MN2PDF_OPTIONS = :mn2pdf
-    MN2PDF_FONT_MANIFEST = :font_manifest_file
+    MN2PDF_FONT_MANIFEST = :font_manifest
 
     def initialize(options)
       @format = :pdf
@@ -20,14 +20,15 @@ module IsoDoc
     end
 
     def pdf_options(_docxml)
-      ret = ""
-      font_manifest_file = @options.dig(MN2PDF_OPTIONS,
-                                        MN2PDF_FONT_MANIFEST) and
-        ret += " --font-manifest #{font_manifest_file}"
+      ret = {}
+      font_manifest = @options.dig(MN2PDF_OPTIONS,
+                                   MN2PDF_FONT_MANIFEST) and
+        ret[MN2PDF_FONT_MANIFEST] = font_manifest
       @aligncrosselements && !@aligncrosselements.empty? and
-        ret += %( --param align-cross-elements="#{@aligncrosselements.gsub(/,/, ' ')}")
+        ret["--param align-cross-elements="] =
+          @aligncrosselements.gsub(/,/, " ")
       @baseassetpath and
-        ret += %( --param baseassetpath="#{@baseassetpath}")
+        ret["--param baseassetpath="] = @baseassetpath
       ret
     end
 

--- a/lib/metanorma/output/xslfo.rb
+++ b/lib/metanorma/output/xslfo.rb
@@ -4,18 +4,10 @@ require_relative "./utils"
 module Metanorma
   module Output
     class XslfoPdf < Base
-      def convert(url_path, output_path, xsl_stylesheet, options = "")
+      def convert(url_path, output_path, xsl_stylesheet, options = {})
         return if url_path.nil? || output_path.nil? || xsl_stylesheet.nil?
 
-        Mn2pdf.convert(quote(url_path), quote(output_path),
-                       quote(xsl_stylesheet), options)
-      end
-
-      def quote(text)
-        return text if /^'.*'$/.match?(text)
-        return text if /^".*"$/.match?(text)
-
-        %("#{text}")
+        Mn2pdf.convert(url_path, output_path, xsl_stylesheet, options)
       end
     end
   end

--- a/spec/isodoc/xslfo_convert_spec.rb
+++ b/spec/isodoc/xslfo_convert_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe IsoDoc do
       },
     )
 
-    expect(convert.pdf_options(nil)).to eq("")
+    expect(convert.pdf_options(nil)).to eq({})
   end
 
   it "test empty pdf_options for nil font_manifest_file" do
@@ -21,20 +21,21 @@ RSpec.describe IsoDoc do
       },
     )
 
-    expect(convert.pdf_options(nil)).to eq("")
+    expect(convert.pdf_options(nil)).to eq({})
   end
 
   it "test --font-manifest pdf_options" do
+    mn2pdf_opts = {
+      IsoDoc::XslfoPdfConvert::MN2PDF_FONT_MANIFEST => "/tmp/manifest.yml",
+    }
     convert = IsoDoc::XslfoPdfConvert.new(
       {
         datauriimage: false,
-        IsoDoc::XslfoPdfConvert::MN2PDF_OPTIONS => {
-          IsoDoc::XslfoPdfConvert::MN2PDF_FONT_MANIFEST => "/tmp/manifest.yml",
-        },
+        IsoDoc::XslfoPdfConvert::MN2PDF_OPTIONS => mn2pdf_opts,
       },
     )
 
-    expect(convert.pdf_options(nil)).to eq(" --font-manifest /tmp/manifest.yml")
+    expect(convert.pdf_options(nil)).to eq(mn2pdf_opts)
   end
 
   it "test --param align-cross-elements pdf_options" do
@@ -46,9 +47,8 @@ RSpec.describe IsoDoc do
     )
 
     expect(convert.pdf_options(nil))
-      .to eq(" --param align-cross-elements=\"clause table note\"")
+      .to eq({ "--param align-cross-elements=" => "clause table note" })
   end
-
 
   it "test --baseassetpath pdf_options" do
     convert = IsoDoc::XslfoPdfConvert.new(
@@ -59,6 +59,6 @@ RSpec.describe IsoDoc do
     )
 
     expect(convert.pdf_options(nil))
-      .to eq(" --param baseassetpath=\"ABC\"")
+      .to eq({ "--param baseassetpath=" => "ABC" })
   end
 end


### PR DESCRIPTION
 - metanorma/metanorma#215

### Depends on 

 - https://github.com/metanorma/mn2pdf-ruby/pull/26

### Related PRs

 - https://github.com/metanorma/metanorma-standoc/pull/551
 - https://github.com/metanorma/metanorma/pull/218