### PR TITLE
Remove unnecessary files from gem archive

### DIFF
--- a/isodoc.gemspec
+++ b/isodoc.gemspec
@@ -24,7 +24,10 @@ Gem::Specification.new do |spec|
 
   spec.bindir        = "bin"
   spec.require_paths = ["lib"]
-  spec.files         = `git ls-files`.split("\n")
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features|.github)/}) \
+    || f.match(%r{\.[a-zA-Z0-9_-]+\.yml|Rakefile|bin/rspec})
+  end
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 


### PR DESCRIPTION
### Intro

During https://github.com/metanorma/metanorma-docker/issues/147 investigation I have found that some our gems contains  unnecessary files which safely can be removed

List of gems (which include specs):
 - `isodoc-i18n`
 - `metanorma-iec`
 - `metanorma-iso`
 - `metanorma-standoc`
 - `metanorma-utils`
 - `relaton`
 - `reverse_adoc`

And almost all our gems include unnecessary configs

### Proposal

 - Skip `spec` in gemspec (list it as `spec.test_files`)
 - Skip CI configuration (.github, .travis)
 - Skip code quality configs (.hund.yml, .rubocop.yml)
 - Skip some scripts from `bin` like `rspec` (maybe something else)