### PR TITLE
Fixed handling of temporary files on Windows

### DIFF
--- a/lib/isodoc/css.rb
+++ b/lib/isodoc/css.rb
@@ -101,6 +101,7 @@ module IsoDoc
         stylesheet = convert_scss(filename, stylesheet, stripwordcss)
       end
       Tempfile.open([File.basename(filename, ".*"), "css"],
+                    mode: File::BINARY | File::SHARE_DELETE,
                     encoding: "utf-8") do |f|
         f.write(stylesheet)
         f

--- a/lib/isodoc/function/utils.rb
+++ b/lib/isodoc/function/utils.rb
@@ -177,7 +177,8 @@ module IsoDoc
         imgtype = imgtype.sub(/\+[a-z0-9]+$/, "") # svg+xml
         imgtype = "png" unless /^[a-z0-9]+$/.match? imgtype
         imgtype == "postscript" and imgtype = "eps"
-        Tempfile.open(["image", ".#{imgtype}"]) do |f|
+        Tempfile.open(["image", ".#{imgtype}"],
+                      mode: File::BINARY | File::SHARE_DELETE) do |f|
           f.binmode
           f.write(Base64.strict_decode64(imgdata))
           @tempfile_cache << f # persist to the end
@@ -186,7 +187,8 @@ module IsoDoc
       end
 
       def save_svg(img)
-        Tempfile.open(["image", ".svg"]) do |f|
+        Tempfile.open(["image", ".svg"],
+                      mode: File::BINARY | File::SHARE_DELETE) do |f|
           f.write(img.to_xml)
           @tempfile_cache << f # persist to the end
           f.path

--- a/lib/isodoc/presentation_function/image.rb
+++ b/lib/isodoc/presentation_function/image.rb
@@ -154,7 +154,6 @@ module IsoDoc
     def cache_dataimage(uri)
       if %r{^data:}.match?(uri)
         uri = save_dataimage(uri)
-        @tempfile_cache << uri
       end
       uri
     end

--- a/lib/isodoc/word_function/postprocess_cover.rb
+++ b/lib/isodoc/word_function/postprocess_cover.rb
@@ -95,7 +95,9 @@ module IsoDoc
           .merge(@meta.labels ? { labels: @meta.labels } : {})
         meta[:filename] = filename
         params = meta.transform_keys(&:to_s)
-        Tempfile.open(%w(header html), encoding: "utf-8") do |f|
+        Tempfile.open(%w(header html),
+                      mode: File::BINARY | File::SHARE_DELETE,
+                      encoding: "utf-8") do |f|
           f.write(template.render(params))
           f
         end

--- a/lib/isodoc/xslfo_convert.rb
+++ b/lib/isodoc/xslfo_convert.rb
@@ -78,6 +78,7 @@ module IsoDoc
     def input_xml_path(input_filename, xml_file, debug)
       docxml, filename, dir = convert_init(xml_file, input_filename, debug)
       input_filename = Tempfile.open([File.basename(filename), ".xml"],
+                                     mode: File::BINARY | File::SHARE_DELETE,
                                      encoding: "utf-8") do |f|
         f.write docxml
         f


### PR DESCRIPTION
Fixes https://github.com/metanorma/isodoc/issues/529; 
Fixes https://github.com/metanorma/packed-mn/issues/210;
Possibly https://github.com/metanorma/ocra/issues/11; 
Possibly https://github.com/metanorma/packed-mn/issues/207

Explanation: https://stackoverflow.com/questions/62995807/errnoeacces-upon-deleting-a-file-on-windows-10

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
