### PR TITLE
Potential fix for code scanning alert no. 35: Bad HTML filtering regexp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gemspec
 
 eval_gemfile("Gemfile.devel") rescue nil
 
-gem "sanitize", "7.0.0"
+gem "sanitize", "~> 7"

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 gemspec
 
 eval_gemfile("Gemfile.devel") rescue nil
+
+gem "sanitize", "7.0.0"

--- a/spec/isodoc/postproc_spec.rb
+++ b/spec/isodoc/postproc_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "sanitize"
 require "fileutils"
 
 options = { wordstylesheet: "spec/assets/word.css",
@@ -1262,8 +1263,9 @@ RSpec.describe IsoDoc do
     html = File.read("test.html")
       .sub(%r{^.*<body}m, "<body")
       .sub(%r{</body>.*$}m, "</body>")
-      .gsub(%r{<script.+?</script>}mi, "<script/>")
-      .sub(%r{(<script/>\s+)+}mi, "<script/>")
+      .gsub(%r{<script.+?</script>}mi, "")
+      .sub(%r{(<script/>\s+)+}mi, "")
+      .then { |html| Sanitize.fragment(html, elements: ['script']) }
     expect(Xml::C14n.format(html)).to be_equivalent_to Xml::C14n.format(output)
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/metanorma/isodoc/security/code-scanning/35](https://github.com/metanorma/isodoc/security/code-scanning/35)

To fix the problem, we should replace the custom regular expression with a well-tested HTML sanitization library. This will ensure that all variations of the `<script>` tag and other potential security issues are properly handled. The `sanitize` gem is a good choice for this purpose.

1. Install the `sanitize` gem.
2. Replace the custom regular expression with a call to the `sanitize` library to remove script tags.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
