### PR TITLE
remove '(all parts)' from citations, leaving it only in references; d…

### DIFF
--- a/lib/isodoc/init.rb
+++ b/lib/isodoc/init.rb
@@ -143,9 +143,9 @@ module IsoDoc
       self.class::AGENCIES.include?(text)
     end
 
-    def docid_l10n(text)
+    def docid_l10n(text, citation: true)
       text.nil? and return text
-      @i18n.all_parts and text.gsub!(/All Parts/i, @i18n.all_parts.downcase)
+      docid_all_parts(text, citation)
       x = Nokogiri::XML::DocumentFragment.parse(text)
       (x.xpath(".//text()") - x.xpath(".//fn//text()")).each do |n|
         n.replace(n.text.gsub(/ /, "&#xa0;"))
@@ -153,10 +153,19 @@ module IsoDoc
       to_xml(x)
     end
 
+    def docid_all_parts(text, citation)
+      if citation
+        text.sub!(%r{\p{Zs}\(all\p{Zs}parts\)}, "")
+      else
+        @i18n.all_parts && !citation and
+          text.gsub!(/all\p{Zs}parts/, @i18n.all_parts.downcase)
+      end
+    end
+
     def docid_prefix(prefix, docid)
       docid = "#{prefix} #{docid}" if prefix && !omit_docid_prefix(prefix) &&
         !/^#{prefix}\b/.match(docid)
-      docid_l10n(docid)
+      docid_l10n(docid, citation: false)
     end
 
     def omit_docid_prefix(prefix)

--- a/lib/isodoc/presentation_function/docid.rb
+++ b/lib/isodoc/presentation_function/docid.rb
@@ -13,7 +13,8 @@ module IsoDoc
       ret = pref_ref_code_parse(bib) or return nil
       ins = bib.at(ns("./docidentifier[last()]"))
       ret.reverse_each do |r|
-        ins.next = "<docidentifier scope='biblio-tag'>#{docid_l10n(r)}</docidentifier>"
+        id = docid_l10n(r, citation: false)
+        ins.next = "<docidentifier scope='biblio-tag'>#{id}</docidentifier>"
       end
       ret
     end

--- a/spec/isodoc/ref_spec.rb
+++ b/spec/isodoc/ref_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe IsoDoc do
                     </semx>
                     <eref bibitemid="ISO16634" id="_21"/>
                     <semx element="eref" source="_21">
-                       <fmt-xref target="ISO16634">ISO 16634:-- (all parts)</fmt-xref>
+                       <fmt-xref target="ISO16634">ISO 16634:--</fmt-xref>
                     </semx>
                     <eref bibitemid="ref1" id="_22"/>
                     <semx element="eref" source="_22">
@@ -537,7 +537,7 @@ RSpec.describe IsoDoc do
                       <a href="#ISO712">ISO 712</a>
                       <a href="#ISBN">[3]</a>
                       <a href="#ISSN">[4]</a>
-                      <a href="#ISO16634">ISO 16634:-- (all parts)</a>
+                      <a href="#ISO16634">ISO 16634:--</a>
                       <a href="#ref1">ICC/167</a>
                       <a href="#ref10">[6]</a>
                       <a href="#ref12">Citn</a>
@@ -676,7 +676,7 @@ RSpec.describe IsoDoc do
                   <a href="#ISO712">ISO 712</a>
                   <a href="#ISBN">[3]</a>
                   <a href="#ISSN">[4]</a>
-                  <a href="#ISO16634">ISO 16634:-- (all parts)</a>
+                  <a href="#ISO16634">ISO 16634:--</a>
                   <a href="#ref1">ICC/167</a>
                   <a href="#ref10">[6]</a>
                   <a href="#ref12">Citn</a>


### PR DESCRIPTION
…ebug i18n of 'all parts': https://github.com/metanorma/mn-samples-icc/issues/16

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
