### PR TITLE
chore: migrate from inkscape-rake to generic-rake workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,10 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/inkscape-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: inkscape,ghostscript
+      submodules: true
+      choco-cache: true
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -10,6 +10,10 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/inkscape-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: inkscape,ghostscript
+      submodules: true
+      choco-cache: true
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Migrate to the consolidated generic-rake.yml workflow. Part of metanorma/ci#259.