### PR TITLE
Route monthyr and MMMddyyyy through ExtendedDateFormatter.format_iso_date

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,1 @@
+gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/format-iso-date-helper"

--- a/lib/isodoc/metadata_date.rb
+++ b/lib/isodoc/metadata_date.rb
@@ -23,21 +23,23 @@ module IsoDoc
     end
 
     def monthyr(isodate)
-      m = /(?<yr>\d\d\d\d)-(?<mo>\d\d)/.match isodate
-      return isodate unless m && m[:yr] && m[:mo]
-
-      l10n("#{months[m[:mo].to_sym]} #{m[:yr]}")
+      out = IsoDoc::ExtendedDateFormatter.format_iso_date(
+        isodate,
+        lang: @lang,
+        year_month: "%B %Y",
+        full: "%B %Y",
+      )
+      out == isodate ? out : l10n(out)
     end
 
     def MMMddyyyy(isodate)
-      isodate.nil? and return nil
-
-      arr = isodate.split("-")
-      arr.size == 1 && (/^\d+$/.match isodate) and
-        return Date.new(*arr.map(&:to_i)).strftime("%Y")
-      arr.size == 2 and
-        return Date.new(*arr.map(&:to_i)).strftime("%B %Y")
-      Date.parse(isodate).strftime("%B %d, %Y")
+      IsoDoc::ExtendedDateFormatter.format_iso_date(
+        isodate,
+        lang: @lang,
+        year: "%Y",
+        year_month: "%B %Y",
+        full: "%B %d, %Y",
+      )
     end
 
     def bibdate(isoxml, _out)

--- a/spec/isodoc/metadata_spec.rb
+++ b/spec/isodoc/metadata_spec.rb
@@ -617,7 +617,7 @@ RSpec.describe IsoDoc do
         publisher: "International Organization for Standardization et International Electrotechnical Commission",
         receiveddate: "XXX",
         revdate: "2016-05",
-        revdate_monthyear: "Mai 2016",
+        revdate_monthyear: "mai 2016",
         script: "Latn",
         stable_untildate: "XXX",
         stage: "Committee Draft",


### PR DESCRIPTION
Part of metanorma/metanorma-plateau#147 (Phase 3 — flavour-copies refactor). Also corrects Title-Case French month capitalisation to CLDR-canonical sentence case (`"Mai" → "mai"`). Pins `isodoc-i18n` to metanorma/isodoc-i18n#24 in `Gemfile.devel` until that PR releases.
