### PR TITLE
Fix layout for sidebar toggle in generated HTML

### DIFF
--- a/lib/isodoc/base_style/nav.scss
+++ b/lib/isodoc/base_style/nav.scss
@@ -131,7 +131,9 @@
     background-color: $colorBg;
     color: $colorFg !important;
     cursor: pointer;
-    z-index: 100;
+    left: 0;
+    top: 0;
+    z-index: 103;
 
     span {
       text-align: center;

--- a/lib/isodoc/base_style/scripts.html
+++ b/lib/isodoc/base_style/scripts.html
@@ -13,24 +13,51 @@
       const jqToggle = $('#toggle');
       const animationSpeed = 'slow';
 
+      if(!jqNav.length || !jqToggle.length) {
+        return;
+      }
+
+      const navWidthExpanded = jqNav.outerWidth();
+      const bodyPaddingLeftExpanded =
+        parseFloat(jqBody.css('paddingLeft')) > 0 ?
+          jqBody.css('paddingLeft') : navWidthExpanded + 'px';
+      const expandedToggleLeft = navWidthExpanded + 'px';
+      let bandWidth = 0;
+
+      $('.document-stage-band:visible, .document-type-band:visible')
+        .each(function() {
+          const bounds = this.getBoundingClientRect();
+          bandWidth = Math.max(bandWidth, bounds.right);
+        });
+
+      const toggleWidth = jqToggle.outerWidth();
+      const collapsedToggleLeft = bandWidth + 'px';
+      const collapsedBodyPaddingLeft = bandWidth + toggleWidth + 'px';
+      jqToggle.css({
+        'left': jqNav.is(':visible') ? expandedToggleLeft : collapsedToggleLeft,
+        'top': '0px'
+      });
+
       jqToggle.on('click', function() {
         const isNavVisible = jqNav.is(':visible');
-        const fullNavWidth = jqNav.outerWidth();
-        const navLeft = isNavVisible ? '-' + fullNavWidth + 'px' : '0px';
-        const bodyMarginLeft = isNavVisible ? '0px' : fullNavWidth + 'px';
+        const navLeft = isNavVisible ? '-' + navWidthExpanded + 'px' : '0px';
+        const bodyPaddingLeft =
+          isNavVisible ? collapsedBodyPaddingLeft : bodyPaddingLeftExpanded;
+        const toggleLeft =
+          isNavVisible ? collapsedToggleLeft : expandedToggleLeft;
 
-        // Stop current animations
         jqNav.stop(true, true);
         jqBody.stop(true, true);
+        jqToggle.stop(true, true);
 
         if(!isNavVisible) {
-            jqNav.show();
+          jqNav.show();
         }
         jqNav.animate({'left': navLeft}, animationSpeed, function() {
           if(isNavVisible) {jqNav.hide()}
         });
-        jqBody.animate({'marginLeft': bodyMarginLeft}, animationSpeed);
-
+        jqBody.animate({'paddingLeft': bodyPaddingLeft}, animationSpeed);
+        jqToggle.animate({'left': toggleLeft}, animationSpeed);
       });
     })();
   </script>
@@ -215,4 +242,3 @@ for (i = 0; i < coll.length; i++) {
   });
 }
 </script>
-

--- a/spec/assets/sidebar.scss
+++ b/spec/assets/sidebar.scss
@@ -1,0 +1,13 @@
+@use 'base_style/nav' as *;
+
+body {
+  @include sidebarNavContainer(360px);
+}
+
+nav {
+  @include sidebarNav(#f7f7f7, 323px, 30px);
+}
+
+#toggle {
+  @include sidebarNavToggle(white, #000);
+}

--- a/spec/isodoc/postproc_spec.rb
+++ b/spec/isodoc/postproc_spec.rb
@@ -147,6 +147,44 @@ RSpec.describe IsoDoc do
     expect(have_cdata_in_script_tags(html)).to be false
   end
 
+  it "generates padding-based sidebar toggle assets" do
+    FileUtils.rm_f "test.html"
+    IsoDoc::HtmlConvert.new(
+      { htmlstylesheet: "spec/assets/sidebar.scss" },
+    ).convert("test", <<~INPUT, false)
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+        <sections>
+          <clause displayorder="1" id="scope" type="scope">
+            <fmt-title>Scope</fmt-title>
+            <p>Text</p>
+          </clause>
+        </sections>
+      </iso-standard>
+    INPUT
+    html = File.read("test.html")
+    expect(html).to include("const bodyPaddingLeftExpanded")
+    expect(html).to include("const expandedToggleLeft = navWidthExpanded + 'px'")
+    expect(html).to include("const toggleWidth = jqToggle.outerWidth()")
+    expect(html).to include("const collapsedToggleLeft = bandWidth + 'px'")
+    expect(html)
+      .to include("const collapsedBodyPaddingLeft = bandWidth + toggleWidth + 'px'")
+    expect(html).to include(
+      "$('.document-stage-band:visible, .document-type-band:visible')",
+    )
+    expect(html)
+      .to include("isNavVisible ? collapsedBodyPaddingLeft : bodyPaddingLeftExpanded")
+    expect(html)
+      .to include("jqBody.animate({'paddingLeft': bodyPaddingLeft}")
+    expect(html).to include("jqToggle.animate({'left': toggleLeft}")
+    expect(html).not_to include("jqBody.animate({'marginLeft'")
+    expect(html).not_to include("const bodyPaddingLeft = isNavVisible ? '0px'")
+    expect(html).not_to include("'padding-left': '360px'")
+    expect(html).not_to include("'padding-left': '30px'")
+    expect(html).to match(
+      /#toggle \{[^}]*left: 0;[^}]*top: 0;[^}]*z-index: 103;/m,
+    )
+  end
+
   it "generates Headless HTML output docs with null configuration from file" do
     FileUtils.rm_f "spec/assets/iso.html"
     IsoDoc::HeadlessHtmlConvert.new(


### PR DESCRIPTION
This PR fixes the generated HTML sidebar toggle so it preserves and restores the document padding instead of shifting the body with margin changes.

The toggle now remains visible beside document stage/type bands when collapsed, and expanding the sidebar restores the original layout. Adds a regression fixture covering the generated sidebar assets.

Closes #793

<img width="1280" height="900" alt="isodoc-sidebar-expanded" src="https://github.com/user-attachments/assets/22122afd-b726-4dc6-8fd0-fc4812012459" />

<img width="1280" height="900" alt="isodoc-sidebar-collapsed" src="https://github.com/user-attachments/assets/797dad56-43b5-4ac6-9380-055cff371f34" />
