### PR TITLE
migrate: unified release workflow (test-gated)

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -3,6 +3,7 @@ name: rake
 on:
   push:
     branches: [ master, main ]
+    tags: [ v* ]
   pull_request:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: release
 
 on:
-  push:
-    tags: [ v* ]
   workflow_dispatch:
     inputs:
       next_version:


### PR DESCRIPTION
## Summary

Migrate isodoc from Pattern B (tag push → release.yml → publish immediately) to the unified test-gated architecture.

### Changes
- **rake.yml**: Add `push: tags: [v*]` trigger so the test matrix runs on tag pushes.
- **release.yml**: Remove `push: tags: [v*]` trigger. Publishing is now test-gated via the do-release chain.

### New release flow

```bash
gh workflow run release.yml -f next_version=patch
```

```
workflow_dispatch → bump + tag + push
  → tag push → rake.yml → test matrix → tests pass
    → do-release → release.yml → publish
```

### Depends on
- metanorma/ci#289 (must be merged first)