### PR TITLE
Render collapsible examples as HTML5 details/summary

### DIFF
--- a/lib/isodoc/function/blocks_example_note.rb
+++ b/lib/isodoc/function/blocks_example_note.rb
@@ -51,7 +51,26 @@ module IsoDoc
       end
 
       def example_parse(node, out)
-        example_div_parse(node, out)
+        if node["collapsible"] == "true"
+          example_collapsible_parse(node, out)
+        else
+          example_div_parse(node, out)
+        end
+      end
+
+      # HTML5 collapsible example: label in <summary>, body in the example div
+      def example_collapsible_parse(node, out)
+        out.details(open: "open") do |det|
+          name = node.at(ns("./fmt-name"))
+          det.summary do |s|
+            name and children_parse(name, s)
+          end
+          det.div(**example_div_attr(node)) do |div|
+            node.children.each do |n|
+              parse(n, div) unless n.name == "fmt-name"
+            end
+          end
+        end
       end
 
       def block_body_first_elem(node)

--- a/spec/isodoc/blocks_spec.rb
+++ b/spec/isodoc/blocks_spec.rb
@@ -120,6 +120,32 @@ RSpec.describe IsoDoc do
       .to be_html4_equivalent_to word
   end
 
+  it "renders collapsible examples as HTML5 details" do
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
+      <preface><foreword id="fwd" displayorder="2">
+      <example id="samplecode" collapsible="true">
+      <fmt-name id="_">EXAMPLE</fmt-name>
+      <p>Hello</p>
+      </example>
+      </foreword></preface>
+      </iso-standard>
+    INPUT
+    html = <<~OUTPUT
+      <details open="open">
+        <summary>EXAMPLE</summary>
+        <div id="samplecode" class="example">
+          <p>Hello</p>
+        </div>
+      </details>
+    OUTPUT
+    output = Nokogiri::HTML5(IsoDoc::HtmlConvert.new({})
+      .convert("test", input, true))
+    output = output.at("//details")
+    expect(strip_guid(output.to_xhtml))
+      .to be_html5_equivalent_to html
+  end
+
   it "processes sequences of examples" do
     input = <<~INPUT
           <iso-standard xmlns="http://riboseinc.com/isoxml">


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/31

Renders `<example collapsible="true">` as HTML5 `<details open>`/`<summary>`: the example label goes into `<summary>`, the body into the `<div class="example">`. This is the HTML5 architectural direction (the move Wyatt initiated), superseding the dormant `.collapsible`/`.hidable` JS toggle. Scope: examples only.

Pairs with the metanorma-standoc PR (recognises `[example%collapsible]` → `collapsible="true"`) and the `collapsible` attribute added to the master grammar in metanorma-model-iso.

🤖
