### PR TITLE
Add Table of Examples (toc type=example)

### DIFF
--- a/lib/isodoc-yaml/i18n-ar.yaml
+++ b/lib/isodoc-yaml/i18n-ar.yaml
@@ -90,6 +90,7 @@ version: الإصدار
 toc_figures: جدول الأرقام
 toc_tables: جدول الجداول
 toc_recommendations: جدول التوصيات
+toc_examples: جدول الأمثلة
 month_january: يناير
 month_february: فبراير
 month_march: مارس

--- a/lib/isodoc-yaml/i18n-de.yaml
+++ b/lib/isodoc-yaml/i18n-de.yaml
@@ -102,6 +102,7 @@ version: Version
 toc_figures: Abbildungsverzeichnis
 toc_tables: Tabellenverzeichnis
 toc_recommendations: Empfehlungenverzeichnis
+toc_examples: Beispielverzeichnis
 month_january: Januar
 month_february: Februar
 month_march: März

--- a/lib/isodoc-yaml/i18n-en.yaml
+++ b/lib/isodoc-yaml/i18n-en.yaml
@@ -102,6 +102,7 @@ version: version
 toc_figures: List of figures
 toc_tables: List of tables
 toc_recommendations: List of recommendations
+toc_examples: List of examples
 month_january: January
 month_february: February
 month_march: March

--- a/lib/isodoc-yaml/i18n-es.yaml
+++ b/lib/isodoc-yaml/i18n-es.yaml
@@ -100,6 +100,7 @@ version: versión
 toc_figures: Table de figuras
 toc_tables: Tabla de tablas
 toc_recommendations: Tabla de recomendaciones
+toc_examples: Tabla de ejemplos
 month_january: Enero
 month_february: Febrero
 month_march: Marzo

--- a/lib/isodoc-yaml/i18n-fr.yaml
+++ b/lib/isodoc-yaml/i18n-fr.yaml
@@ -98,6 +98,7 @@ edition: édition
 toc_figures: Table des figures
 toc_tables: Table des tableaux
 toc_recommendations: Table de recommandations
+toc_examples: Table des exemples
 month_january: Janvier
 month_february: Février
 month_march: Mars

--- a/lib/isodoc-yaml/i18n-ja.yaml
+++ b/lib/isodoc-yaml/i18n-ja.yaml
@@ -101,6 +101,7 @@ version: 版
 toc_figures: 図一覧
 toc_tables: 表一覧
 toc_recommendations: 推奨一覧
+toc_examples: 例一覧
 month_january: 1月
 month_february: 2月
 month_march: 3月

--- a/lib/isodoc-yaml/i18n-ru.yaml
+++ b/lib/isodoc-yaml/i18n-ru.yaml
@@ -164,6 +164,7 @@ version: версия
 toc_figures: Таблица фигур
 toc_tables: Таблица таблиц
 toc_recommendations: Таблица рекомендаций
+toc_examples: Таблица примеров
 month_january: Январь
 month_february: Февраль
 month_march: Март

--- a/lib/isodoc-yaml/i18n-zh-Hans.yaml
+++ b/lib/isodoc-yaml/i18n-zh-Hans.yaml
@@ -91,6 +91,7 @@ version: 版本
 toc_figures: 数字列表
 toc_tables: 表列表
 toc_recommendations: 建议清单
+toc_examples: 示例列表
 month_january: 一月
 month_february: 二月
 month_march: 三月

--- a/lib/isodoc/convert.rb
+++ b/lib/isodoc/convert.rb
@@ -45,6 +45,7 @@ module IsoDoc
     # tocfigures: add ToC for figures
     # toctables: add ToC for tables
     # tocrecommendations: add ToC for rcommendations
+    # tocexamples: add ToC for examples
     # fonts: fontist fonts to install
     # fontlicenseagreement: fontist font license agreement
     # modspecidentifierbase: base prefix for any Modspec identifiers

--- a/lib/isodoc/init.rb
+++ b/lib/isodoc/init.rb
@@ -169,6 +169,7 @@ module IsoDoc
       @tocfigures = options[:tocfigures]
       @toctables = options[:toctables]
       @tocrecommendations = options[:tocrecommendations]
+      @tocexamples = options[:tocexamples]
     end
 
     AGENCIES = %w(ISO IEC ITU IETF NIST OGC IEEE BIPM BSI BS JIS IANA UN W3C

--- a/lib/isodoc/presentation_function/metadata.rb
+++ b/lib/isodoc/presentation_function/metadata.rb
@@ -93,15 +93,17 @@ module IsoDoc
     end
 
     def toc_metadata(docxml)
-      @tocfigures || @toctables || @tocrecommendations or return
+      @tocfigures || @toctables || @tocrecommendations || @tocexamples or return
       ins = extension_insert(docxml)
       @tocfigures and
         ins.add_child "<toc type='figure'><title>#{@i18n.toc_figures}</title></toc>"
       @toctables and
         ins << "<toc type='table'><title>#{@i18n.toc_tables}</title></toc>"
-      @tocfigures and
+      @tocrecommendations and
         ins << "<toc type='recommendation'><title>#{@i18n.toc_recommendations}" \
         "</title></toc>"
+      @tocexamples and
+        ins << "<toc type='example'><title>#{@i18n.toc_examples}</title></toc>"
     end
 
     def fonts_metadata(xmldoc)

--- a/lib/isodoc/word_function/body.rb
+++ b/lib/isodoc/word_function/body.rb
@@ -161,6 +161,7 @@ module IsoDoc
         @toctablestitle = xml.at(ns("//#{toc}[@type = 'table']/title"))&.text
         @tocrecommendationstitle =
           xml.at(ns("//#{toc}[@type = 'recommendation']/title"))&.text
+        @tocexamplestitle = xml.at(ns("//#{toc}[@type = 'example']/title"))&.text
       end
 
       def table_of_contents(clause, out)

--- a/lib/isodoc/word_function/postprocess_toc.rb
+++ b/lib/isodoc/word_function/postprocess_toc.rb
@@ -27,6 +27,7 @@ module IsoDoc
         toc += make_table_word_toc(docxml)
         toc += make_figure_word_toc(docxml)
         toc += make_recommendation_word_toc(docxml)
+        toc += make_example_word_toc(docxml)
         toc
       end
 
@@ -91,6 +92,10 @@ module IsoDoc
            recommendationtitle recommendationtesttitle)
       end
 
+      def example_toc_class
+        %w(example-title)
+      end
+
       def toc_word_class_list(classes)
         classes.map { |x| "#{x},1" }.join(",")
       end
@@ -114,6 +119,13 @@ module IsoDoc
         <<~TOC
           <span lang="EN-GB"><span style='mso-element:field-begin'></span><span style='mso-spacerun:yes'>&#xA0;</span>TOC
           \\h \\z \\t "#{toc_word_class_list figure_toc_class}" <span style='mso-element:field-separator'></span></span>
+        TOC
+      end
+
+      def word_toc_example_preface1
+        <<~TOC
+          <span lang="EN-GB"><span style='mso-element:field-begin'></span><span style='mso-spacerun:yes'>&#xA0;</span>TOC
+          \\h \\z \\t "#{toc_word_class_list example_toc_class}" <span style='mso-element:field-separator'></span></span>
         TOC
       end
 
@@ -162,6 +174,21 @@ module IsoDoc
         end
         toc.sub(/(<p class="MsoToc1">)/,
                 %{\\1#{word_toc_reqt_preface1}}) + WORD_TOC_SUFFIX1
+      end
+
+      def example_toc_xpath
+        attr = example_toc_class.map { |x| "@class = '#{x}'" }
+        "//p[#{attr.join(' or ')}]"
+      end
+
+      def make_example_word_toc(docxml)
+        (docxml.at(example_toc_xpath) && @tocexamplestitle) or return ""
+        toc = %{<p class="TOCTitle">#{@tocexamplestitle}</p>}
+        docxml.xpath(example_toc_xpath).each do |h|
+          toc += word_toc_entry(1, header_strip(h))
+        end
+        toc.sub(/(<p class="MsoToc1">)/,
+                %{\\1#{word_toc_example_preface1}}) + WORD_TOC_SUFFIX1
       end
 
       def recommmendation_sort_key(header)

--- a/spec/isodoc/presentation_xml_metadata_spec.rb
+++ b/spec/isodoc/presentation_xml_metadata_spec.rb
@@ -56,13 +56,17 @@ RSpec.describe IsoDoc do
           <toc type='recommendation'>
             <title>List of recommendations</title>
           </toc>
+          <toc type='example'>
+            <title>List of examples</title>
+          </toc>
         </metanorma-extension>
       </iso-standard>
     OUTPUT
     xml = Nokogiri::XML(IsoDoc::PresentationXMLConvert
       .new({ tocfigures: true,
              toctables: true,
-             tocrecommendations: true }
+             tocrecommendations: true,
+             tocexamples: true }
       .merge(presxml_options))
       .convert("test", input, true))
     xml.xpath("//xmlns:preface | //xmlns:localized-strings | //xmlns:sections")


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/32

Adds the **Table of Examples**, mirroring the figures/tables "list-of" machinery:
- `toc_metadata` emits `<toc type='example'>` into the presentation XML (and fixes the recommendation toc, which was gated on `@tocfigures` instead of `@tocrecommendations`);
- `tocexamples` option in `init_toc`; Word ToC in `postprocess_toc` (keyed on the `example-title` class);
- `toc_examples` i18n in all 8 locales (English authoritative; other translations best-effort, for review).

HTML renders automatically (`toc_parse` is type-agnostic). **PDF/XSL rendering is a separate ticket** (XSLT is maintained separately). Full breakdown on the pdfa#32 ticket.

🤖
