### PR TITLE
Classify number-format options in isodoc; warn on unclassified plurimath options

### DIFF
--- a/lib/isodoc/presentation_function/math.rb
+++ b/lib/isodoc/presentation_function/math.rb
@@ -50,19 +50,44 @@ module IsoDoc
                                   precision: num_precision(num.text))
     end
 
+    # The `data-metanorma-numberformat` options metanorma types, by target
+    # type. The single source of truth lives here in isodoc (metanorma's
+    # concern), not in plurimath.
+    NUMBERFORMAT_INTEGER = %i(precision significant digit_count group_digits
+                              fraction_group_digits base).freeze
+    NUMBERFORMAT_SYMBOL = %i(notation exponent_sign number_sign locale
+                             hex_capital).freeze
+    NUMBERFORMAT_NULLABLE = %i(base_prefix base_suffix).freeze
+    # plurimath options metanorma deliberately passes through unchanged (string)
+    NUMBERFORMAT_PASSTHROUGH = %i(fraction_group decimal group times e).freeze
+    NUMBERFORMAT_KNOWN = (NUMBERFORMAT_INTEGER + NUMBERFORMAT_SYMBOL +
+                          NUMBERFORMAT_NULLABLE + NUMBERFORMAT_PASSTHROUGH).freeze
+
     def numberformat_type(ret)
-      %i(precision significant digit_count group_digits fraction_group_digits
-         base)
-        .each do |i|
-        ret[i] &&= ret[i].to_i
-      end
-      %i(notation exponent_sign number_sign locale hex_capital).each do |i|
-        ret[i] &&= ret[i].to_sym
-      end
-      %i(base_prefix base_suffix).each do |i|
+      numberformat_unclassified_warn
+      NUMBERFORMAT_INTEGER.each { |i| ret[i] &&= ret[i].to_i }
+      NUMBERFORMAT_SYMBOL.each { |i| ret[i] &&= ret[i].to_sym }
+      NUMBERFORMAT_NULLABLE.each do |i|
         ["", "nil"].include?(ret[i]) and ret[i] = nil
       end
       ret
+    end
+
+    # Union plurimath's option defaults against metanorma's known lists, and
+    # warn (once) on anything plurimath exposes that metanorma has not
+    # classified -- e.g. a passthrough option added upstream (potentially via a
+    # direct Peter Wyatt request) that we would otherwise be none the wiser of.
+    # DEFAULT_OPTIONS is the passthrough watch-point, not plurimath's entire
+    # option surface. See metanorma/basicdoc-models#35.
+    def numberformat_unclassified_warn
+      @numberformat_warned and return
+      @numberformat_warned = true
+      unknown = Plurimath::Formatter::Standard::DEFAULT_OPTIONS.keys -
+        NUMBERFORMAT_KNOWN
+      unknown.empty? and return
+      warn "[isodoc] plurimath number-format options not classified by " \
+           "metanorma (treated as string passthrough): #{unknown.join(', ')}. " \
+           "Classify them in IsoDoc numberformat_type."
     end
 
     def explicit_number_formatter(num, locale, options)

--- a/spec/isodoc/numberformat_classification_spec.rb
+++ b/spec/isodoc/numberformat_classification_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+# basicdoc-models#35: number-format option typing lives in isodoc; we union
+# metanorma's known lists against plurimath's DEFAULT_OPTIONS and warn on any
+# plurimath option metanorma has not classified (e.g. a passthrough option
+# added upstream).
+RSpec.describe IsoDoc::PresentationXMLConvert do
+  subject(:conv) { described_class.new(language: "en", script: "Latn") }
+
+  describe "#numberformat_unclassified_warn" do
+    it "stays silent when every plurimath option is classified" do
+      expect { conv.numberformat_unclassified_warn }.not_to output.to_stderr
+    end
+
+    it "warns, naming a plurimath option metanorma has not classified" do
+      stub_const(
+        "Plurimath::Formatter::Standard::DEFAULT_OPTIONS",
+        Plurimath::Formatter::Standard::DEFAULT_OPTIONS
+          .merge(brand_new_passthrough: 0),
+      )
+      expect { conv.numberformat_unclassified_warn }
+        .to output(/not classified.*brand_new_passthrough/m).to_stderr
+    end
+
+    it "warns at most once per instance" do
+      stub_const(
+        "Plurimath::Formatter::Standard::DEFAULT_OPTIONS",
+        Plurimath::Formatter::Standard::DEFAULT_OPTIONS
+          .merge(brand_new_passthrough: 0),
+      )
+      $stderr = StringIO.new
+      conv.numberformat_unclassified_warn # first call warns (captured)
+      $stderr = STDERR
+      expect { conv.numberformat_unclassified_warn }.not_to output.to_stderr
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/metanorma/isodoc/issues/805

Keeps number-format option typing in isodoc as constants, and warns once on plurimath options metanorma has not classified (unioned against plurimath `DEFAULT_OPTIONS`) — so an upstream passthrough addition surfaces itself, with no plurimath change. Tests added. Full rationale on the issue.

🤖
