### PR TITLE
Render custom table class additively, decouple borders from class

### DIFF
--- a/lib/isodoc/function/table.rb
+++ b/lib/isodoc/function/table.rb
@@ -49,9 +49,12 @@ module IsoDoc
       # Bordering is governed by %plain only, NOT by the presence of a custom
       # @class (metanorma/metanorma-pdfa#33). A non-plain table -- including one
       # carrying a custom class, or the internal modspec variant -- keeps the
-      # ISO borders. (klass retained for call-site arity / flavour overrides.)
-      def bordered_table_style(node, _klass = nil)
+      # ISO borders. The internal `rouge-line-table` (sourcecode line numbering)
+      # is the exception: like %plain it is mutually exclusive with MsoISOTable
+      # and takes no ISO border additions.
+      def bordered_table_style(node, klass = nil)
         node["plain"] == "true" and return ""
+        klass == "rouge-line-table" and return ""
         "border-width:1px;border-spacing:0;"
       end
 
@@ -65,11 +68,12 @@ module IsoDoc
 
       # metanorma/metanorma-pdfa#33: a custom @class is ADDITIVE -- it augments
       # the computed base class (MsoISOTable, or "plain" under %plain) rather
-      # than replacing it, and is orthogonal to bordering. `modspec` stays a
-      # grandfathered internal value with replace semantics.
+      # than replacing it, and is orthogonal to bordering. `modspec` and the
+      # sourcecode line-numbering `rouge-line-table` stay grandfathered internal
+      # values with replace semantics (mutually exclusive with MsoISOTable).
       def table_html_class(node, custom)
         node["plain"] == "true" and return ["plain", custom].compact.join(" ")
-        custom == "modspec" and return "modspec"
+        %w(modspec rouge-line-table).include?(custom) and return custom
         ["MsoISOTable", custom].compact.join(" ")
       end
 
@@ -158,10 +162,14 @@ module IsoDoc
         STYLE
       end
 
-      # Cell bordering follows %plain only, not the custom @class (see
-      # bordered_table_style). metanorma/metanorma-pdfa#33
+      # Cell bordering follows %plain only, not the custom @class, with
+      # `rouge-line-table` excluded like %plain (see bordered_table_style).
+      # metanorma/metanorma-pdfa#33
       def table_bordered?(node)
-        node.parent.parent["plain"] != "true"
+        table = node.parent.parent
+        table["plain"] == "true" and return false
+        table["class"] == "rouge-line-table" and return false
+        true
       end
 
       def tr_parse(node, out, ord, totalrows, header)

--- a/lib/isodoc/function/table.rb
+++ b/lib/isodoc/function/table.rb
@@ -46,19 +46,31 @@ module IsoDoc
         end
       end
 
-      def bordered_table_style(node, klass)
-        bordered = "border-width:1px;border-spacing:0;"
-        (node["plain"] != "true" && (%w(modspec).include?(klass) || !klass)) or
-          bordered = ""
-        bordered
+      # Bordering is governed by %plain only, NOT by the presence of a custom
+      # @class (metanorma/metanorma-pdfa#33). A non-plain table -- including one
+      # carrying a custom class, or the internal modspec variant -- keeps the
+      # ISO borders. (klass retained for call-site arity / flavour overrides.)
+      def bordered_table_style(node, _klass = nil)
+        node["plain"] == "true" and return ""
+        "border-width:1px;border-spacing:0;"
       end
 
       def table_attrs(node)
         c = node["class"]
         style = table_attrs_style(node, c)
         attr_code(id: node["id"],
-                  class: node["plain"] == "true" ? "plain" : (c || "MsoISOTable"),
+                  class: table_html_class(node, c),
                   style: style, title: node["alt"])
+      end
+
+      # metanorma/metanorma-pdfa#33: a custom @class is ADDITIVE -- it augments
+      # the computed base class (MsoISOTable, or "plain" under %plain) rather
+      # than replacing it, and is orthogonal to bordering. `modspec` stays a
+      # grandfathered internal value with replace semantics.
+      def table_html_class(node, custom)
+        node["plain"] == "true" and return ["plain", custom].compact.join(" ")
+        custom == "modspec" and return "modspec"
+        ["MsoISOTable", custom].compact.join(" ")
       end
 
       def table_attrs_style(node, klass)
@@ -146,10 +158,10 @@ module IsoDoc
         STYLE
       end
 
+      # Cell bordering follows %plain only, not the custom @class (see
+      # bordered_table_style). metanorma/metanorma-pdfa#33
       def table_bordered?(node)
-        node.parent.parent["plain"] == "true" and return false
-        c = node.parent.parent["class"]
-        %w(modspec).include?(c) || !c
+        node.parent.parent["plain"] != "true"
       end
 
       def tr_parse(node, out, ord, totalrows, header)

--- a/lib/isodoc/word_function/table.rb
+++ b/lib/isodoc/word_function/table.rb
@@ -84,12 +84,14 @@ module IsoDoc
         super.merge(attr_code(ret))
       end
 
+      # %plain or an explicit @style still suppresses the default border; a
+      # custom @class no longer nulls it. The class is HTML-only and is not
+      # emitted to Word output (Word CSS is too inflexible), but a custom-class
+      # table must still render as a normal bordered ISO table.
+      # metanorma/metanorma-pdfa#33
       def table_border_css(node)
-        c = node["class"]
         style = "border-spacing:0;border-width:1px;"
         node["style"] || node["plain"] == "true" and style = ""
-        (%w(modspec).include?(c) || !c) or style = nil
-        node["plain"] == "true" and style = ""
         style
       end
 

--- a/lib/isodoc/word_function/table.rb
+++ b/lib/isodoc/word_function/table.rb
@@ -88,10 +88,14 @@ module IsoDoc
       # custom @class no longer nulls it. The class is HTML-only and is not
       # emitted to Word output (Word CSS is too inflexible), but a custom-class
       # table must still render as a normal bordered ISO table.
-      # metanorma/metanorma-pdfa#33
+      # Exception: the internal `rouge-line-table` (sourcecode line numbering)
+      # takes no ISO border and keeps its own class -- returning nil drops the
+      # Word MsoISOTable override (see table_attrs) so the HTML super class
+      # survives. metanorma/metanorma-pdfa#33
       def table_border_css(node)
         style = "border-spacing:0;border-width:1px;"
         node["style"] || node["plain"] == "true" and style = ""
+        node["class"] == "rouge-line-table" and style = nil
         style
       end
 

--- a/spec/isodoc/table_spec.rb
+++ b/spec/isodoc/table_spec.rb
@@ -1,6 +1,68 @@
 require "spec_helper"
 
 RSpec.describe IsoDoc do
+  # metanorma/metanorma-pdfa#33: a table's custom @class is ADDITIVE on the HTML
+  # class (augments MsoISOTable / "plain"), and is orthogonal to bordering --
+  # bordering is governed by %plain alone, so a custom class no longer strips
+  # the ISO borders. The class is HTML-only; Word keeps its computed class.
+  def table_custom_class_html(table_xml)
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <sections><clause id="c1">#{table_xml}</clause></sections>
+      </iso-standard>
+    INPUT
+    pres = IsoDoc::PresentationXMLConvert.new(presxml_options)
+      .convert("test", input, true)
+    Nokogiri::HTML5(IsoDoc::HtmlConvert.new({}).convert("test", pres, true))
+      .at("//table")
+  end
+
+  it "augments the HTML table class with a custom class, keeping ISO borders" do
+    t = table_custom_class_html(
+      '<table id="t1" class="sortable"><tbody><tr><td>A</td></tr></tbody></table>',
+    )
+    expect(t["class"]).to eq "MsoISOTable sortable"
+    expect(t["style"]).to include "border-width:1px"
+  end
+
+  it "appends a custom class to a %plain table (CSS from scratch)" do
+    t = table_custom_class_html(
+      '<table id="t1" plain="true" class="sortable">' \
+      "<tbody><tr><td>A</td></tr></tbody></table>",
+    )
+    expect(t["class"]).to eq "plain sortable"
+  end
+
+  it "passes multiple space-separated table classes through to HTML" do
+    t = table_custom_class_html(
+      '<table id="t1" class="sortable fixed"><tbody><tr><td>A</td></tr></tbody></table>',
+    )
+    expect(t["class"]).to eq "MsoISOTable sortable fixed"
+  end
+
+  it "leaves a class-less table as MsoISOTable, bordered (backward compat)" do
+    t = table_custom_class_html(
+      '<table id="t1"><tbody><tr><td>A</td></tr></tbody></table>',
+    )
+    expect(t["class"]).to eq "MsoISOTable"
+    expect(t["style"]).to include "border-width:1px"
+  end
+
+  it "does not emit the custom class to Word, but keeps Word borders" do
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <sections><clause id="c1">
+      <table id="t1" class="sortable"><tbody><tr><td>A</td></tr></tbody></table>
+      </clause></sections></iso-standard>
+    INPUT
+    pres = IsoDoc::PresentationXMLConvert.new(presxml_options)
+      .convert("test", input, true)
+    t = Nokogiri::HTML5(IsoDoc::WordConvert.new({}).convert("test", pres, true))
+      .at("//table")
+    expect(t["class"]).not_to include "sortable"
+    expect(t["style"]).to include "border-width:1px"
+  end
+
   it "processes IsoXML tables" do
     mock_uuid_increment
     input = <<~INPUT


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/33

Render a table's custom `@class` **additively**: it augments the computed base class (`MsoISOTable`, or `plain` under `%plain`) rather than replacing it, and is **orthogonal to bordering** — bordering is governed by `%plain` alone, so a custom class no longer strips the ISO borders (`bordered_table_style`, `table_bordered?`). `modspec` stays a grandfathered internal value. HTML-only: the class is not emitted to Word, but Word's `table_border_css` is fixed defensively so a custom-class table keeps its borders. Specs added. Full narrative on the issue.

🤖
