### PR TITLE
Render multiple classes on pseudocode and admonition (saga)

### DIFF
--- a/lib/isodoc/function/blocks.rb
+++ b/lib/isodoc/function/blocks.rb
@@ -16,7 +16,11 @@ module IsoDoc
       end
 
       def figure_parse(node, out)
-        node["class"] == "pseudocode" || node["type"] == "pseudocode" and
+        # metanorma/metanorma-standoc#1197: "pseudocode" may be one of several
+        # space-separated classes; dispatch on its presence, not equality, so a
+        # custom class alongside it is preserved.
+        node["class"]&.split&.include?("pseudocode") ||
+          node["type"] == "pseudocode" and
           return pseudocode_parse(node, out)
         @in_figure = true
         figure_parse1(node, out)
@@ -33,7 +37,10 @@ module IsoDoc
       end
 
       def pseudocode_attrs(node)
-        attr_code(id: node["id"], class: "pseudocode", style: keep_style(node))
+        classes = node["class"]&.split || []
+        classes.include?("pseudocode") or classes.unshift("pseudocode")
+        attr_code(id: node["id"], class: classes.join(" "),
+                  style: keep_style(node))
       end
 
       def pseudocode_tag

--- a/lib/isodoc/function/blocks_example_note.rb
+++ b/lib/isodoc/function/blocks_example_note.rb
@@ -156,7 +156,11 @@ module IsoDoc
       end
 
       def admonition_class(node)
-        "Admonition #{admonition_subclass(node)}".strip
+        # metanorma/metanorma-standoc#1197: admonition @class is unused by the
+        # type-driven labelling/numbering, so it is repurposed for additive
+        # custom HTML classes appended after the built-in Admonition classes.
+        ["Admonition", admonition_subclass(node), node["class"]]
+          .compact.join(" ").strip
       end
 
       def admonition_subclass(node)

--- a/spec/isodoc/custom_class_spec.rb
+++ b/spec/isodoc/custom_class_spec.rb
@@ -45,4 +45,24 @@ RSpec.describe IsoDoc do
     expect(html).to include('class="sourcecode"')
     expect(html).not_to match(/class="[^"]*\bcc-/)
   end
+
+  # pseudocode dispatches on "pseudocode" being among the classes, and passes
+  # the other classes through (metanorma/metanorma-standoc#1197)
+  it "renders custom classes on a pseudocode alongside the dispatch class" do
+    html = html_for(
+      '<figure id="ps1" class="pseudocode cc-ps"><name>P</name>' \
+      '<p id="pp">a step</p></figure>',
+    )
+    expect(html).to match(/class="[^"]*\bpseudocode\b[^"]*"/)
+    expect(html).to match(/class="[^"]*\bcc-ps\b[^"]*"/)
+  end
+
+  # admonition @class is unused by type-driven labelling, so custom classes are
+  # rendered additively after the built-in Admonition classes
+  it "renders custom classes on an admonition additively" do
+    html = html_for(
+      '<admonition id="a1" type="warning" class="cc-adm"><p id="ap">x</p></admonition>',
+    )
+    expect(html).to match(/class="[^"]*\bAdmonition\b[^"]*\bcc-adm\b[^"]*"/)
+  end
 end


### PR DESCRIPTION
pseudocode: dispatch on "pseudocode" being among the space-separated classes (not equality), and render the full class list, so a custom class rides alongside the dispatch class.

admonition: its @class is unused by the type-driven labelling/numbering, so repurpose it for additive custom HTML classes appended after the built-in Admonition classes.

Refs https://github.com/metanorma/metanorma-standoc/issues/1197

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
