### PR TITLE
Add dl to the custom-@class block-coverage spec

### DIFF
--- a/spec/isodoc/custom_class_spec.rb
+++ b/spec/isodoc/custom_class_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe IsoDoc do
       "p" => ["cc-par", "x"],
       "ul" => ["cc-ul", "<li><p id='l1'>x</p></li>"],
       "ol" => ["cc-ol", "<li><p id='l2'>x</p></li>"],
+      "dl" => ["cc-dl", "<dt>t</dt><dd id='d1'><p id='dp'>x</p></dd>"],
       "note" => ["cc-note", "<p id='p3'>x</p>"],
     }.each do |tag, (token, inner)|
       name = tag.split.first


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/712

## Summary

Completes custom-`@class` render coverage for **definition lists (dl)** — the one block the block-custom-class saga (metanorma/metanorma-standoc#1197) missed on the render side. Surfaced via iso-10303#712.

isodoc's `dl_attrs` already renders `class: node["class"]`, so **no code change is needed**; this adds the missing spec coverage — `custom_class_spec.rb` exercised sourcecode/figure/example/quote/p/ul/ol/note but not dl.

## Changes
- `spec/isodoc/custom_class_spec.rb` — add `dl` to the across-blocks custom-class render assertion.

Green (4/0).

🤖
