### PR TITLE
populate meta[:bibdata] with full relaton bibdata hash for Liquid templates

### DIFF
--- a/isodoc.gemspec
+++ b/isodoc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bigdecimal"
   spec.add_dependency "html2doc", "~> 1.11.0"
   # spec.add_dependency "isodoc-i18n", "~> 1.1.0" # already in relaton-render and mn-requirements
-  # spec.add_dependency "relaton-cli"
+  spec.add_dependency "relaton-cli", "~> 2.1.0"
   # spec.add_dependency "metanorma-utils", "~> 1.5.0" # already in isodoc-i18n
   spec.add_dependency "mn2pdf", ">= 2.13"
   spec.add_dependency "mn-requirements", "~> 0.5.0"

--- a/lib/isodoc/function/setup.rb
+++ b/lib/isodoc/function/setup.rb
@@ -43,6 +43,7 @@ module IsoDoc
       def info(isoxml, out)
         @meta.localdir = @localdir
         @meta.presentation isoxml, out
+        @meta.bibdata isoxml, out
         @meta.code_css isoxml, out
         @meta.title isoxml, out
         @meta.subtitle isoxml, out

--- a/lib/isodoc/metadata.rb
+++ b/lib/isodoc/metadata.rb
@@ -1,5 +1,6 @@
 require_relative "metadata_date"
 require_relative "metadata_contributor"
+require_relative "metadata_bibdata"
 
 module IsoDoc
   class Metadata

--- a/lib/isodoc/metadata_bibdata.rb
+++ b/lib/isodoc/metadata_bibdata.rb
@@ -1,0 +1,73 @@
+require "relaton-cli"
+
+module IsoDoc
+  class BibdataConfig < ::Lutaml::Model::Serializable
+    class Bibdata < ::Lutaml::Model::Serializable
+      model ::Relaton::Bib::ItemData
+    end
+
+    attribute :bibdata, Bibdata
+
+    xml do
+      root "metanorma"
+      map_element "bibdata", to: :bibdata, with: { from: :bibdata_from_xml,
+                                                   to: :bibdata_to_xml }
+    end
+
+    def bibdata_from_xml(model, node)
+      node or return
+      model.bibdata = Relaton::Cli.parse_xml(node.adapter_node.native)
+    end
+
+    def bibdata_to_xml(model, parent, doc); end
+  end
+
+  class Metadata
+    def bibdata(isoxml, _out)
+      set(:bibdata, bibdata_hash(isoxml))
+    end
+
+    private
+
+    def bibdata_hash(isoxml)
+      b = isoxml.at("//bibdata") || isoxml.at("//xmlns:bibdata") or return
+      key = b.to_xml
+      # memoised by content, not unconditionally: after
+      # docidentifier_boilerplate_isodoc resolves Liquid docidentifiers,
+      # refresh_isodoc_bibdata re-runs this walker on the same Metadata
+      # instance and must re-parse the changed bibdata
+      @bibdata_hash_cache ||= {}
+      @bibdata_hash_cache.key?(key) or
+        @bibdata_hash_cache[key] = bibdata_hash_parse(key)
+      @bibdata_hash_cache[key]
+    end
+
+    def bibdata_hash_parse(bibdata_xml)
+      stripped = Nokogiri::XML(bibdata_xml)
+      stripped.remove_namespaces!
+      # Drop @boilerplate="true" docidentifiers before handing the
+      # bibdata to Relaton::Cli.parse_xml: their content is an
+      # unresolved Liquid template, and recent relaton-iho /
+      # relaton-cc / etc. eagerly call pubid in their docidentifier
+      # content= setter, which crashes on raw Liquid syntax. The
+      # template variables for substitution come from other bibdata
+      # fields (seriesabbr, docnumeric, …), not from the
+      # docidentifier itself, so dropping it here does not affect
+      # what we feed back into isodoc.meta. Substitution still runs
+      # on the original xmldoc via standoc's
+      # docidentifier_boilerplate_isodoc; afterwards
+      # refresh_isodoc_bibdata re-runs this walker to seed
+      # meta[:bibdata] with the resolved docidentifier.
+      # See https://github.com/metanorma/metanorma/issues/558.
+      stripped.xpath("//docidentifier[@boilerplate = 'true']").each(&:remove)
+      bib = BibdataConfig.from_xml(
+        "<metanorma>#{stripped.root.to_xml}</metanorma>",
+      ).bibdata or return nil
+      YAML.safe_load(bib.to_yaml, permitted_classes: [Date, Symbol],
+                                  symbolize_names: true)
+    rescue StandardError => e
+      warn "Failed to parse bibdata for Liquid template use: #{e.message}"
+      nil
+    end
+  end
+end

--- a/spec/assets/bibdata_mathml_title.yml
+++ b/spec/assets/bibdata_mathml_title.yml
@@ -1,0 +1,30 @@
+---
+id: BIPM201904
+type: standard
+title:
+- language: en
+  content: |-
+    Internal Standard Reference Data for qNMR: 4,4-Dimethyl-4-silapentane-1-sulfonic acid-<stem block="false" type="MathML">
+      <math>
+        <mstyle displaystyle="false">
+          <msub>
+            <mi>d</mi>
+            <mn>6</mn>
+          </msub>
+        </mstyle>
+      </math>
+      <asciimath>d_6</asciimath>
+    </stem> [ISRD-07]
+  type: title-main
+  format: text/plain
+docidentifier:
+- content: BIPM-2019/04
+  type: BIPM
+  primary: true
+language:
+- en
+script:
+- Latn
+status:
+  stage:
+    content: published

--- a/spec/assets/htmlcover_bibdata.html
+++ b/spec/assets/htmlcover_bibdata.html
@@ -1,0 +1,3 @@
+<p class="coverpage-bibdata">BIBDATA:
+{%- assign doi = bibdata.docidentifier | where: "type", "DOI" | first -%}
+{{ doi.content }}|{{ bibdata.status.stage.content }}|{{ bibdata.docnumber }}|{{ bibdata.ext.doctype.content }}</p>

--- a/spec/isodoc/metadata_bibdata_spec.rb
+++ b/spec/isodoc/metadata_bibdata_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe IsoDoc::Metadata do
+  def info(input)
+    c = IsoDoc::Convert.new({})
+    c.convert_init(input, "test", false)
+    c.info(Nokogiri::XML(input), nil)
+  end
+
+  it "populates meta[:bibdata] preserving embedded MathML in a title" do
+    input = <<~XML
+      <metanorma xmlns="https://www.metanorma.org/ns/standoc">
+        <bibdata type="standard">
+          <title language="en" format="text/plain" type="title-main">Internal Standard Reference Data for qNMR: 4,4-Dimethyl-4-silapentane-1-sulfonic acid-<stem block="false" type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><mstyle displaystyle="false"><msub><mi>d</mi><mn>6</mn></msub></mstyle></math><asciimath>d_6</asciimath></stem> [ISRD-07]</title>
+          <docidentifier primary="true" type="BIPM">BIPM-2019/04</docidentifier>
+          <language>en</language>
+          <script>Latn</script>
+          <status><stage>published</stage></status>
+        </bibdata>
+      </metanorma>
+    XML
+    m = info(input)
+    expect(m[:bibdata]).not_to be_nil
+    # schema_version tracks Relaton model versions and would force this
+    # fixture to be re-blessed on every Relaton release, so strip it.
+    actual = m[:bibdata].dup
+    actual.delete(:schema_version)
+    expected = YAML.safe_load(
+      File.read("spec/assets/bibdata_mathml_title.yml"),
+      permitted_classes: [Date, Symbol], symbolize_names: true,
+    )
+    expect(actual).to eq expected
+  end
+
+  it "excludes boilerplate docidentifiers from meta[:bibdata]" do
+    input = <<~XML
+      <metanorma xmlns="https://www.metanorma.org/ns/standoc">
+        <bibdata type="standard">
+          <docidentifier primary="true" type="OGC">24-041</docidentifier>
+          <docidentifier type="DOI">10.62973/24-041</docidentifier>
+          <docidentifier boilerplate="true">{{ seriesabbr }} {{ docnumeric }}</docidentifier>
+          <docnumber>24041</docnumber>
+          <status><stage>published</stage></status>
+        </bibdata>
+      </metanorma>
+    XML
+    m = info(input)
+    expect(m[:bibdata][:docidentifier])
+      .to eq [{ content: "24-041", type: "OGC", primary: true },
+              { content: "10.62973/24-041", type: "DOI" }]
+  end
+
+  it "returns nil meta[:bibdata] without raising on unparseable bibdata" do
+    input = <<~XML
+      <metanorma xmlns="https://www.metanorma.org/ns/standoc">
+        <bibdata type="standard">
+          <date type="published"><on>not-a-date</on></date>
+          <status><stage>published</stage></status>
+        </bibdata>
+      </metanorma>
+    XML
+    m = nil
+    expect { m = info(input) }.not_to raise_error
+    expect(m).to have_key(:bibdata)
+  end
+
+  it "leaves meta[:bibdata] nil when there is no bibdata" do
+    m = info("<metanorma xmlns='https://www.metanorma.org/ns/standoc'>" \
+             "<sections/></metanorma>")
+    expect(m[:bibdata]).to be_nil
+  end
+
+  it "re-parses when the bibdata changes on the same Metadata instance" do
+    input1 = <<~XML
+      <metanorma xmlns="https://www.metanorma.org/ns/standoc">
+        <bibdata type="standard"><docnumber>1111</docnumber>
+        <status><stage>draft</stage></status></bibdata>
+      </metanorma>
+    XML
+    input2 = input1.sub("1111", "2222")
+    c = IsoDoc::Convert.new({})
+    c.convert_init(input1, "test", false)
+    expect(c.info(Nokogiri::XML(input1), nil)[:bibdata][:docnumber])
+      .to eq "1111"
+    expect(c.info(Nokogiri::XML(input2), nil)[:bibdata][:docnumber])
+      .to eq "2222"
+  end
+
+  it "renders bibdata fields in the HTML cover page through Liquid" do
+    FileUtils.rm_f "test.html"
+    IsoDoc::HtmlConvert.new(
+      { htmlstylesheet: "spec/assets/html.scss",
+        htmlcoverpage: "spec/assets/htmlcover_bibdata.html" },
+    ).convert("test", <<~INPUT, false)
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <bibdata type="standard">
+        <docidentifier primary="true" type="OGC">24-041</docidentifier>
+        <docidentifier type="DOI">10.62973/24-041</docidentifier>
+        <docnumber>24041</docnumber>
+        <status><stage>published</stage></status>
+        <ext><doctype>standard</doctype></ext>
+      </bibdata>
+      <sections/>
+      </iso-standard>
+    INPUT
+    html = File.read("test.html")
+    expect(html)
+      .to include "BIBDATA:10.62973/24-041|published|24041|standard"
+    FileUtils.rm_f "test.html"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,8 +43,10 @@ def new_xrefs
 end
 
 def metadata(hash)
-  hash.sort.to_h.delete_if do |_k, v|
-    v.nil? || (v.respond_to?(:empty?) && v.empty?)
+  # :bibdata is the full relaton hash of //bibdata, tested in
+  # metadata_bibdata_spec.rb; too bulky to pin in each metadata test
+  hash.sort.to_h.delete_if do |k, v|
+    k == :bibdata || v.nil? || (v.respond_to?(:empty?) && v.empty?)
   end
 end
 


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/24
Refs https://github.com/metanorma/metanorma-ogc/issues/955

Hoists the whole-bibdata → `meta[:bibdata]` parse from metanorma-generic into the base `Isodoc::Metadata` walker chain, so `{{ bibdata.* }}` is available to every flavour's Liquid templates. Companion PR: metanorma/metanorma-generic (removal of the compile-side copy). Full narrative on the tickets.

🤖
