### PR TITLE
stageabbr reads stage/@abbreviation; draft_stage? fallback seam

### DIFF
--- a/lib/isodoc/metadata.rb
+++ b/lib/isodoc/metadata.rb
@@ -72,15 +72,29 @@ module IsoDoc
         set(:substage_display, i1)
       (i2 = xml.at(ns("//bibdata/status/iteration"))&.text) and
         set(:iteration, i2)
-      !published && set(:stageabbr, stage_abbr(s.text))
+      # @abbreviation is authoritative (e.g. supplied by a taste through
+      # :docstage-abbrev:); read here rather than in stage_abbr, so that
+      # flavour stage_abbr overrides do not mask it
+      published or
+        set(:stageabbr, s["abbreviation"] || stage_abbr(s.text))
     end
 
     def published_default(xml)
       override = xml.at(ns("//semantic-metadata/stage-published"))&.text
-      default = override || "true"
-      ret = default == "false"
-      set(:unpublished, ret)
-      default == "true"
+      if override.nil?
+        stage = xml.at(ns("//bibdata/status/stage#{NOLANG}"))&.text
+        override = draft_stage?(stage) ? "false" : "true"
+      end
+      set(:unpublished, override == "false")
+      override == "true"
+    end
+
+    # Is the stage a draft (unpublished) stage? Overridable seam for
+    # documents whose XML does not carry semantic-metadata/
+    # stage-published (which is authoritative when present). Base
+    # default preserves historical behaviour: absent flag => published.
+    def draft_stage?(_stage)
+      false
     end
 
     def stage_abbr(docstatus)

--- a/spec/isodoc/metadata_spec.rb
+++ b/spec/isodoc/metadata_spec.rb
@@ -224,6 +224,13 @@ RSpec.describe IsoDoc do
     m = metadata(c.info(Nokogiri::XML(input
       .sub("<stage-published>false</stage-published>", "")), nil))
     expect(m[:unpublished]).to be false
+
+    # stage/@abbreviation (e.g. from a taste's :docstage-abbrev:) is
+    # authoritative over initials-derivation
+    m = metadata(c.info(Nokogiri::XML(input
+      .sub("<stage>Committee Draft</stage>",
+           "<stage abbreviation='RC'>Committee Draft</stage>")), nil))
+    expect(m[:stageabbr]).to eq "RC"
   end
 
   it "processes IsoXML metadata #2" do


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/24

Part of the taste stage-repertoire takeover: tastes validate input stages against their own repertoire and advertise the mapped base stages to the flavour as `:docstage-valid:`, which supersedes the flavour's recognised-stage list. Companion PRs in metanorma-standoc, metanorma-generic, metanorma-taste, isodoc, metanorma-ieee, metanorma-nist, metanorma-iso; release metanorma-standoc first, metanorma-taste last. Full narrative on the ticket.

🤖
