### PR TITLE
DO NOT MERGE — stack test for html2doc#110 (plurimath ~> 0.11.4)

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,5 +1,5 @@
 # CI-only stack test for html2doc PR #110 (plurimath ~> 0.11.4).
-# Pin html2doc to the PR branch so bundler resolves the whole stack against
-# the proposed plurimath 0.11.x line. DO NOT MERGE.
-# https://github.com/metanorma/html2doc/pull/110
-gem "html2doc", git: "https://github.com/metanorma/html2doc.git", branch: "rt-update-plurimath"
+# Pin html2doc to an isolation branch (1.11.1 baseline + plurimath ~> 0.11.4),
+# so bundler resolves the whole stack against plurimath 0.11.x with no version
+# confound. DO NOT MERGE. https://github.com/metanorma/html2doc/pull/110
+gem "html2doc", git: "https://github.com/metanorma/html2doc.git", branch: "test/plurimath-0.11.4-stackcheck"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,5 @@
+# CI-only stack test for html2doc PR #110 (plurimath ~> 0.11.4).
+# Pin html2doc to the PR branch so bundler resolves the whole stack against
+# the proposed plurimath 0.11.x line. DO NOT MERGE.
+# https://github.com/metanorma/html2doc/pull/110
+gem "html2doc", git: "https://github.com/metanorma/html2doc.git", branch: "rt-update-plurimath"


### PR DESCRIPTION
Refs https://github.com/metanorma/html2doc/pull/110

**DO NOT MERGE.** CI-only stack test for metanorma/html2doc#110 (plurimath `~> 0.11.4`).

This branch adds a `Gemfile.devel` pinning html2doc to its PR branch `rt-update-plurimath`, so this repo's CI resolves the whole bundle against the proposed plurimath 0.11.x line. A green run here is one of the gates for merging html2doc#110 into main — see the governance ticket metanorma/html2doc#109.

Close without merging once CI has reported.

🤖
