### PR TITLE
Adapt number formatting to plurimath 0.11.x

### DIFF
--- a/lib/isodoc/presentation_function/math.rb
+++ b/lib/isodoc/presentation_function/math.rb
@@ -59,7 +59,8 @@ module IsoDoc
                              hex_capital).freeze
     NUMBERFORMAT_NULLABLE = %i(base_prefix base_suffix).freeze
     # plurimath options metanorma deliberately passes through unchanged (string)
-    NUMBERFORMAT_PASSTHROUGH = %i(fraction_group decimal group times e).freeze
+    NUMBERFORMAT_PASSTHROUGH = %i(fraction_group decimal group times e
+                                  padding).freeze
     NUMBERFORMAT_KNOWN = (NUMBERFORMAT_INTEGER + NUMBERFORMAT_SYMBOL +
                           NUMBERFORMAT_NULLABLE + NUMBERFORMAT_PASSTHROUGH).freeze
 

--- a/spec/isodoc/presentation_xml_numbers_override_spec.rb
+++ b/spec/isodoc/presentation_xml_numbers_override_spec.rb
@@ -1048,7 +1048,7 @@ RSpec.describe IsoDoc do
            </math>
          </stem>
          <fmt-stem type="MathML">
-           <semx element="stem" source="_">1,1e0</semx>
+           <semx element="stem" source="_">1,10'0e0</semx>
          </fmt-stem>
          <stem type="MathML" id="_">
            <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -1491,7 +1491,7 @@ RSpec.describe IsoDoc do
            </math>
          </stem>
          <fmt-stem type="MathML">
-           <semx element="stem" source="_">1,1e0</semx>
+           <semx element="stem" source="_">1,10'0e0</semx>
          </fmt-stem>
          <stem type="MathML" id="_">
            <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -1936,7 +1936,7 @@ RSpec.describe IsoDoc do
            </math>
          </stem>
          <fmt-stem type="MathML">
-           <semx element="stem" source="_">1,1e0</semx>
+           <semx element="stem" source="_">1,10'0e0</semx>
          </fmt-stem>
          <stem type="MathML" id="_">
            <math xmlns="http://www.w3.org/1998/Math/MathML">

--- a/spec/isodoc/presentation_xml_numbers_spec.rb
+++ b/spec/isodoc/presentation_xml_numbers_spec.rb
@@ -943,7 +943,7 @@ RSpec.describe IsoDoc do
                     </math>
                  </stem>
                  <fmt-stem type="MathML">
-                    <semx element="stem" source="_">30,000</semx>
+                    <semx element="stem" source="_">30,000.00'00'0</semx>
                  </fmt-stem>
                  <stem type="MathML" id="_">
                     <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -1083,14 +1083,14 @@ RSpec.describe IsoDoc do
                                 </mrow>
                              </mrow>
                              <mrow>
-                                <mn>1,000</mn>
+                                <mn>1,000.00'00'0</mn>
                              </mrow>
                           </munderover>
                           <mfenced open="(" close=")">
                              <mtable>
                                 <mtr>
                                    <mtd>
-                                      <mn>1,000</mn>
+                                      <mn>1,000.00'00'0</mn>
                                    </mtd>
                                 </mtr>
                                 <mtr>
@@ -1112,7 +1112,7 @@ RSpec.describe IsoDoc do
                              <mrow>
                                 <mfenced open="(" close=")">
                                    <mrow>
-                                      <mn>1</mn>
+                                      <mn>1.00'00'0</mn>
                                       <mo>−</mo>
                                       <mi>p</mi>
                                    </mrow>
@@ -1130,7 +1130,7 @@ RSpec.describe IsoDoc do
                              <mrow>
                                 <mfenced open="(" close=")">
                                    <mrow>
-                                      <mn>1</mn>
+                                      <mn>1.00'00'0</mn>
                                       <mo>−</mo>
                                       <mi>p</mi>
                                    </mrow>


### PR DESCRIPTION
Refs https://github.com/metanorma/html2doc/pull/110

Adapts isodoc number formatting to plurimath 0.11.x, which the stack is moving to via html2doc#110.

**What changed upstream:** plurimath 0.11.x adds a `padding` number-format option, and now *honours* `significant`/`precision` by padding trailing zeros — where 0.10.x silently stripped them. isodoc already computes `significant`/`precision` from the **source notation** (`num_totaldigits`/`num_precision`), capturing the author's trailing zeros before `normalise_number`'s `BigDecimal` collapses them. In other words isodoc was always asking for the padding; 0.10.x just dropped the instruction, and 0.11.x now renders what isodoc intended.

**This PR:**
- classifies the new `padding` option as passthrough (`NUMBERFORMAT_PASSTHROUGH`);
- updates the number-spec expected outputs to the now-correct padded forms (e.g. `0.1100e1` → `1,10'0e0` not `1,1e0`; integers under `precision: 5` → `30,000.00'00'0`).

The non-decimal-base workaround (metanorma/isodoc#788) is **retained** — verified empirically that 0.11.x still needs it for hex-fractional precision.

**Coordination:** these specs require plurimath 0.11.x, so this PR's own CI (which resolves plurimath `~> 0.10.1` transitively via `html2doc ~> 1.11.0`) stays red until the plurimath bump lands. It is validated under 0.11.x via the full-stack test on metanorma-cli. Merge in coordination with html2doc#110.

🤖
