### PR TITLE
admonition icons: underscore spaces in type for metadata lookup

### DIFF
--- a/lib/isodoc/presentation_function/block.rb
+++ b/lib/isodoc/presentation_function/block.rb
@@ -101,9 +101,18 @@ module IsoDoc
       labelled_autonum(lbl, elem["id"] || elem["original-id"], num)
     end
 
+    # The presentation-metadata element is named from the document
+    # attribute :presentation-metadata-admonition-icon-{type}:, whose name
+    # cannot contain spaces; so spaced admonition types ("safety
+    # precautions") address it with spaces replaced by underscores --
+    # underscore, not hyphen, to avoid collision with genuinely hyphenated
+    # type names. Interpolating the raw type made the XPath invalid and
+    # fatal (#760). The i18n lookup keeps the raw type: i18n keys may
+    # legitimately contain spaces.
     def admonition_icon(elem)
+      type = elem["type"]&.tr(" ", "_")
       icon = elem.document
-        .at(ns("//presentation-metadata/admonition-icon-#{elem['type']}"))&.text
+        .at(ns("//presentation-metadata/admonition-icon-#{type}"))&.text
       icon ||= @i18n.labels.dig("admonition-icon", elem["type"])
       icon and return "<span class='fmt-admonition-icon'>#{icon}</span>"
     end

--- a/spec/isodoc/blocks_notes_spec.rb
+++ b/spec/isodoc/blocks_notes_spec.rb
@@ -1079,4 +1079,68 @@ RSpec.describe IsoDoc do
     expect(strip_guid(pres_output))
       .to be_xml_equivalent_to presxml
   end
+
+  it "processes admonition icons for types containing spaces (#760)" do
+    # The metadata element name substitutes underscores for the spaces in
+    # the admonition type; the raw type used to be interpolated into the
+    # XPath, which was an invalid expression and fatal
+    input = <<~INPUT
+          <iso-standard xmlns="http://riboseinc.com/isoxml">
+          <presentation-metadata>
+            <admonition-icon-safety_precautions>⚠️</admonition-icon-safety_precautions>
+          </presentation-metadata>
+          <preface><foreword id="fwd">
+          <admonition id="_70234f78-64e5-4dfc-8b6f-f3f037348b69" type="safety precautions">
+        <p id="_e94663cc-2473-4ccc-9a72-983a74d989f2">Wear gloves.</p>
+      </admonition>
+          <admonition id="_70234f78-64e5-4dfc-8b6f-f3f037348b6a" type="safety precautions">
+          <name>Title</name>
+        <p id="_e94663cc-2473-4ccc-9a72-983a74d989f3">Wear gloves.</p>
+      </admonition>
+          </foreword></preface>
+          </iso-standard>
+    INPUT
+    presxml = <<~INPUT
+         <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
+        <presentation-metadata>
+          <admonition-icon-safety_precautions>⚠️</admonition-icon-safety_precautions>
+        </presentation-metadata>
+        <preface>
+          <clause type="toc" id="_" displayorder="1">
+            <fmt-title depth="1" id="_">Table of contents</fmt-title>
+          </clause>
+          <foreword id="fwd" displayorder="2">
+            <title id="_">Foreword</title>
+            <fmt-title depth="1" id="_">
+              <semx element="title" source="_">Foreword</semx>
+            </fmt-title>
+            <admonition id="_" type="safety precautions">
+              <fmt-name id="_">
+                <span class="fmt-caption-label">
+                  <span class="fmt-element-name"><span class="fmt-admonition-icon">⚠️</span>SAFETY PRECAUTIONS</span>
+                </span>
+              </fmt-name>
+              <p id="_">Wear gloves.</p>
+            </admonition>
+            <admonition id="_" type="safety precautions">
+              <name id="_">Title</name>
+              <fmt-name id="_">
+                <span class="fmt-caption-label">
+                  <span class="fmt-admonition-icon">⚠️</span>
+                </span>
+                <span class="fmt-caption-delim"/>
+                <semx element="name" source="_">Title</semx>
+              </fmt-name>
+              <p id="_">Wear gloves.</p>
+            </admonition>
+          </foreword>
+        </preface>
+      </iso-standard>
+    INPUT
+    pres_output = IsoDoc::PresentationXMLConvert
+      .new(presxml_options)
+      .convert("test", input, true)
+    expect(strip_guid(pres_output))
+      .to be_xml_equivalent_to presxml
+  end
 end


### PR DESCRIPTION
Refs https://github.com/metanorma/isodoc/issues/760

Diagnosis and design rationale in the ticket (spaced admonition types made the presentation-metadata icon XPath fatally invalid; spaces now map to underscores for the metadata element name only).

🤖
