### PR TITLE
Allow html2doc 1.12 (rt-update-plurimath)

### DIFF
--- a/isodoc.gemspec
+++ b/isodoc.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64"
   spec.add_dependency "bigdecimal"
-  spec.add_dependency "html2doc", "~> 1.11.0"
+  spec.add_dependency "html2doc", "~> 1.11"
   # spec.add_dependency "isodoc-i18n", "~> 1.1.0" # already in relaton-render and mn-requirements
   spec.add_dependency "relaton-cli", "~> 2.1.0"
   # spec.add_dependency "metanorma-utils", "~> 1.5.0" # already in isodoc-i18n


### PR DESCRIPTION
html2doc's `rt-update-plurimath` branch (1.12.0) updates its plurimath dependency to `~> 0.11.6` for corrected OMML math output in Word documents.

isodoc's `~> 1.11.0` constraint rejects html2doc 1.12.0, which makes Gemfiles that track the html2doc branch unresolvable.

This relaxes the constraint to `~> 1.11` so both the 1.11.x releases and the 1.12 line satisfy it. No isodoc code changes needed — isodoc does not use plurimath directly.