### PR TITLE
Allow relaton-cli 3.0.0.pre (relaton 3.0.0.pre chain)

### DIFF
--- a/isodoc.gemspec
+++ b/isodoc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bigdecimal"
   spec.add_dependency "html2doc", "~> 1.12"
   # spec.add_dependency "isodoc-i18n", "~> 1.1.0" # already in relaton-render and mn-requirements
-  spec.add_dependency "relaton-cli", "~> 2.1.0"
+  spec.add_dependency "relaton-cli", ">= 2.1.0", "< 3.1.0"
   # spec.add_dependency "metanorma-utils", "~> 1.5.0" # already in isodoc-i18n
   spec.add_dependency "mn2pdf", ">= 2.13"
   spec.add_dependency "mn-requirements", "~> 0.5.0"


### PR DESCRIPTION
The relaton 3.0.0.pre.alpha line (relaton-cli → relaton → relaton-*) is the pubid-2-native chain required by metanorma-document 0.4.0 (`relaton-bib >= 2.2.0.pre.alpha.1`, `pubid ~> 2.0.0.pre.alpha`).

isodoc's `~> 2.1.0` constraint keeps the bundle on the relaton 2.1 stable line, making metanorma-document 0.4.0 unresolvable.

This widens the constraint to `>= 2.1.0, < 3.1.0` so both the stable 2.1.x releases and the 3.0.0.pre.alpha chain satisfy it. Bundler will resolve to 3.0.0.pre.alpha.1 when metanorma-document 0.4.0 is present, and stay on 2.1.x stable otherwise.