### PR TITLE
Migrate std_docid_semantic to pubid 2

### DIFF
--- a/isodoc.gemspec
+++ b/isodoc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bigdecimal"
   spec.add_dependency "html2doc", "~> 1.12"
   # spec.add_dependency "isodoc-i18n", "~> 1.1.0" # already in relaton-render and mn-requirements
-  spec.add_dependency "relaton-cli", "~> 2.1.0"
+  spec.add_dependency "relaton-cli", ">= 2.1.0", "< 3.1.0"
   # spec.add_dependency "metanorma-utils", "~> 1.5.0" # already in isodoc-i18n
   spec.add_dependency "mn2pdf", ">= 2.13"
   spec.add_dependency "mn-requirements", "~> 0.5.0"

--- a/lib/isodoc/presentation_function/docid_semantic.rb
+++ b/lib/isodoc/presentation_function/docid_semantic.rb
@@ -22,7 +22,7 @@ module IsoDoc
       # wasn't in the input (e.g. "REF4" -> "IEEE Std REF4"). Refuse to
       # annotate when the parser has invented structure not present in the
       # input -- detected by a non-identity round-trip.
-      return id if result.nil?
+      return std_docid_semantic_full(id) if result.nil?
 
       result
     rescue StandardError

--- a/lib/isodoc/presentation_function/docid_semantic.rb
+++ b/lib/isodoc/presentation_function/docid_semantic.rb
@@ -30,38 +30,50 @@ module IsoDoc
     end
 
     # pubid 2 has no universal Pubid::Registry.parse: try each registered
-    # flavor. Three outcomes:
+    # flavor. Outcomes:
     #   1. A flavor round-trips the input AND renders annotation markup —
     #      return it (some flavors' renderers ignore annotated: and
     #      return plain text; those need the regex fallback below).
-    #   2. A flavor parses but synthesizes different structure
+    #   2. A flavor parses but synthesizes structure the input lacks
     #      (e.g. "REF4" -> "IEEE Std REF4") — return the input unchanged
     #      (1.x's round-trip guard).
-    #   3. Nothing parses, or a round-tripper renders plain — nil, so the
-    #      caller uses the regex fallback (1.x's ParseError path).
+    #   3. Nothing parses, a round-tripper renders plain, or the parse
+    #      only canonicalizes FORM (e.g. em-dash year -> "--") — nil, so
+    #      the caller uses the regex fallback, which preserves the
+    #      original string (1.x's ParseError path).
     def pubid_parse(string)
       Pubid.eager_load_flavors!
       parsed_any = false
       plain_roundtrip = false
+      canonicalized = false
       Pubid::Registry.flavors.each_value do |flavor|
         next unless flavor.respond_to?(:parse)
 
         begin
           parsed = flavor.parse(string)
           parsed_any = true
-          next unless parsed.to_s == string
+          if parsed.to_s == string
+            annotated = parsed.to_s(annotated: true)
+            return annotated if annotated != parsed.to_s
 
-          annotated = parsed.to_s(annotated: true)
-          return annotated if annotated != parsed.to_s
-
-          plain_roundtrip = true
+            plain_roundtrip = true
+          elsif dash_normalize(parsed.to_s) == dash_normalize(string)
+            canonicalized = true
+          end
         rescue StandardError
           next
         end
       end
-      return string if parsed_any && !plain_roundtrip
+      return string if parsed_any && !plain_roundtrip && !canonicalized
 
       nil
+    end
+
+    # Compare strings ignoring dash FORM (em-dash / double dash / single
+    # dash), so a parse that only canonicalizes punctuation is not
+    # mistaken for structure synthesis.
+    def dash_normalize(string)
+      string.tr("—", "-").gsub("--", "-")
     end
 
     # Regex-based fallback when Pubid::Registry cannot parse the id. Emits

--- a/lib/isodoc/presentation_function/docid_semantic.rb
+++ b/lib/isodoc/presentation_function/docid_semantic.rb
@@ -16,16 +16,43 @@ module IsoDoc
     end
 
     def std_docid_semantic_parse(id)
-      parsed = Pubid::Registry.parse(id)
+      result = pubid_parse(id)
       # Pubid::Ieee in particular happily parses any "letters+digits" token
       # as an IEEE Std identifier and synthesises an "IEEE Std" prefix that
       # wasn't in the input (e.g. "REF4" -> "IEEE Std REF4"). Refuse to
       # annotate when the parser has invented structure not present in the
       # input -- detected by a non-identity round-trip.
-      return id if parsed.to_s != id
-      parsed.to_s(annotated: true)
-    rescue Pubid::Core::Errors::ParseError
+      return id if result.nil?
+
+      result
+    rescue StandardError
       std_docid_semantic_full(id)
+    end
+
+    # pubid 2 has no universal Pubid::Registry.parse: try each registered
+    # flavor and keep the first parse that round-trips the input exactly
+    # AND renders annotation markup (some flavors' renderers ignore
+    # `annotated:` and return plain text; prefer one that annotates).
+    # Falls back to the first round-tripper when none annotate.
+    def pubid_parse(string)
+      Pubid.eager_load_flavors!
+      plain_winner = nil
+      Pubid::Registry.flavors.each_value do |flavor|
+        next unless flavor.respond_to?(:parse)
+
+        begin
+          parsed = flavor.parse(string)
+          next unless parsed.to_s == string
+
+          annotated = parsed.to_s(annotated: true)
+          return annotated if annotated != parsed.to_s
+
+          plain_winner ||= annotated
+        rescue StandardError
+          next
+        end
+      end
+      plain_winner
     end
 
     # Regex-based fallback when Pubid::Registry cannot parse the id. Emits

--- a/lib/isodoc/presentation_function/docid_semantic.rb
+++ b/lib/isodoc/presentation_function/docid_semantic.rb
@@ -30,29 +30,38 @@ module IsoDoc
     end
 
     # pubid 2 has no universal Pubid::Registry.parse: try each registered
-    # flavor and keep the first parse that round-trips the input exactly
-    # AND renders annotation markup (some flavors' renderers ignore
-    # `annotated:` and return plain text; prefer one that annotates).
-    # Falls back to the first round-tripper when none annotate.
+    # flavor. Three outcomes:
+    #   1. A flavor round-trips the input AND renders annotation markup —
+    #      return it (some flavors' renderers ignore annotated: and
+    #      return plain text; those need the regex fallback below).
+    #   2. A flavor parses but synthesizes different structure
+    #      (e.g. "REF4" -> "IEEE Std REF4") — return the input unchanged
+    #      (1.x's round-trip guard).
+    #   3. Nothing parses, or a round-tripper renders plain — nil, so the
+    #      caller uses the regex fallback (1.x's ParseError path).
     def pubid_parse(string)
       Pubid.eager_load_flavors!
-      plain_winner = nil
+      parsed_any = false
+      plain_roundtrip = false
       Pubid::Registry.flavors.each_value do |flavor|
         next unless flavor.respond_to?(:parse)
 
         begin
           parsed = flavor.parse(string)
+          parsed_any = true
           next unless parsed.to_s == string
 
           annotated = parsed.to_s(annotated: true)
           return annotated if annotated != parsed.to_s
 
-          plain_winner ||= annotated
+          plain_roundtrip = true
         rescue StandardError
           next
         end
       end
-      plain_winner
+      return string if parsed_any && !plain_roundtrip
+
+      nil
     end
 
     # Regex-based fallback when Pubid::Registry cannot parse the id. Emits


### PR DESCRIPTION
pubid 2 removed the universal `Pubid::Registry.parse` (human-readable identifiers now parse via flavor modules: `Pubid::Iso.parse` et al.) and the `Pubid::Core::Errors` hierarchy. `std_docid_semantic` (used by presentation-XML docidentifier annotation) was broken on pubid 2.0.0.pre with `undefined method 'parse' for Pubid::Registry` / `uninitialized constant Pubid::Core::Errors`.

`std_docid_semantic_parse` now tries each registered flavor and keeps the first parse that round-trips the input exactly AND renders annotation markup. The annotation check matters: some flavors' renderers ignore `annotated:` and return plain text — e.g. `bsi` parsing an IEC identifier wins alphabetically over `iec` and would suppress the spans entirely.

Preserved behavior:
- Round-trip guard against synthesized structure (`REF4` → `IEEE Std REF4` returns the input unchanged)
- Regex fallback (`std_docid_semantic_full`) for identifiers no flavor can parse
- `IEV` and blank/numeric ids pass through untouched

Verified: `ISO 8601-1:2019`, `IEC 60050-351:2013`, `ISO/FDIS 8601-1:2019(E)` annotate with publisher/docnumber/part/year/stage/language spans; `REF4` and `IEV` pass through.