### PR TITLE
Strip formatting whitespace before sourcecode body (pdfa#67)

### DIFF
--- a/lib/isodoc/presentation_function/sourcecode.rb
+++ b/lib/isodoc/presentation_function/sourcecode.rb
@@ -51,7 +51,19 @@ module IsoDoc
 
     def sourcecode1(elem)
       ret1 = semx_fmt_dup(elem)
-      b = ret1.at(ns(".//body")) and b.replace(b.children)
+      if (b = ret1.at(ns(".//body")))
+        # Remove formatting whitespace *preceding* the body (e.g. the newlines
+        # standoc emits around a <name> with inline markup). Once the body is
+        # unwrapped and the name removed, such stray whitespace would be lexed
+        # as leading blank lines of code. Whitespace after the body and the
+        # verbatim body content itself are untouched, so genuine code
+        # indentation is preserved.
+        b.parent.children.each do |c|
+          c == b and break
+          c.text? && c.text.strip.empty? and c.remove
+        end
+        b.replace(b.children)
+      end
       source_label(elem)
       source_highlight(ret1, elem["linenums"] == "true", elem["lang"])
       callouts(elem)

--- a/spec/isodoc/sourcecode_spec.rb
+++ b/spec/isodoc/sourcecode_spec.rb
@@ -1,6 +1,28 @@
 require "spec_helper"
 
 RSpec.describe IsoDoc do
+  it "does not leak leading blank lines from a sourcecode title with inline "\
+     "markup (metanorma-pdfa#67)" do
+    # A <name> with inline markup makes standoc serialise the sourcecode with
+    # stray newlines around <name>/<body>; these must not be lexed as leading
+    # blank lines of code.
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <preface><foreword id="X">
+      <sourcecode id="_" lang="xml">
+      <name id="_">Title with letter <tt>A</tt></name>
+      <body>&lt;P&gt;
+      A
+      &lt;/P&gt;</body></sourcecode>
+      </foreword></preface>
+      </iso-standard>
+    INPUT
+    pres = IsoDoc::PresentationXMLConvert.new(presxml_options)
+      .convert("test", input, true)
+    fmt = Nokogiri::XML(pres).tap(&:remove_namespaces!).at_xpath("//fmt-sourcecode")
+    expect(fmt.inner_html).not_to match(/\A[\r\n]/)
+  end
+
   it "processes sourcecode" do
     input = <<~INPUT
           <iso-standard xmlns="http://riboseinc.com/isoxml">


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/67

The isodoc half of metanorma-pdfa#67 (belt-and-braces with metanorma-standoc). A sourcecode `<name>` with inline markup makes standoc emit stray formatting whitespace around `<name>`/`<body>`; `sourcecode1` unwrapped the body and removed the name, leaving that whitespace to be lexed by Rouge as **two leading blank lines** (HTML + PDF, since both share the presentation XML). Now strips whitespace-only nodes preceding `<body>` before unwrapping — the verbatim content, code indentation, and trailing/annotation whitespace are untouched. Full root-cause narrative on the ticket.

## Test plan

- New regression spec in `spec/isodoc/sourcecode_spec.rb` (feeds the stray-whitespace semantic, asserts no leading blank line).
- `spec/isodoc/sourcecode_spec.rb` green (9 examples).

🤖
