### PR TITLE
Cap symbols-dl term column so AsciiMath source length can't blow it out

### DIFF
--- a/lib/isodoc/base_style/reset.scss
+++ b/lib/isodoc/base_style/reset.scss
@@ -137,6 +137,18 @@ dl {
   }
 }
 
+// metanorma-taste#150: a symbols definition list holds the AsciiMath *source*
+// string in its dt (HTML renders math client-side via async MathJax, which never
+// reflows the grid), so a long source blows out the max-content term column and
+// pushes every definition far right. Cap the term column of stem-bearing dls so
+// the term-to-definition gap stays bounded; plain/abbreviation dls keep
+// max-content, which is correct for them. 8em is a crude, tunable ceiling.
+// STOPGAP: remove this rule and restore plain max-content once HTML emits
+// server-side MathML (the term column will then size to the rendered symbol).
+dl:has(dt .stem) {
+  grid-template-columns: fit-content(8em) auto;
+}
+
 b, strong {
   font-weight: bold;
 }


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-taste/issues/150

In HTML, a Symbols definition list is a CSS grid with a `max-content` term column
(isodoc `base_style/reset.scss`). For an AsciiMath symbol the `<dt>` holds the raw
AsciiMath **source string** (`<span class="stem">(#(…)#)</span>`) — HTML renders
math client-side via MathJax (asciimath2jax), loaded `async`, so the browser sizes
the term column from the wide source at first paint and never reflows to the narrow
rendered math. A long source therefore pushes every definition far right
(metanorma-taste#150). Abbreviation dls are fine — plain text measures accurately.

Cap the term column of stem-bearing dls so the gap stays bounded:

```scss
dl:has(dt .stem) {
  grid-template-columns: fit-content(8em) auto;
}
```

Plain and abbreviation dls keep `max-content`, which is correct for them. `8em` is
a deliberately crude, tunable ceiling.

**Deliberate stopgap.** The proper fix is rendering server-side MathML in HTML
(tracked separately, low priority); when that lands, this cap must be removed and
plain `max-content` restored — with rendered math in the DOM, `max-content` sizes
to the widest *rendered* symbol, which is correct.

## Test plan
- SCSS compiles; the rule renders as `dl:has(dt .stem) { grid-template-columns: fit-content(8em) auto }`.
- isodoc `blocks_spec` (dl/stem/formula paths) green.
- Visual (reviewer): a symbols list mixing short and long AsciiMath stems no longer
  widens the definition column with the source length. HTML/MathJax render — eyeball.

🤖
