### PR TITLE
Extend xrefstyle=full to captioned assets (tables, figures, examples…)

### DIFF
--- a/lib/isodoc/xref/xref_anchor.rb
+++ b/lib/isodoc/xref/xref_anchor.rb
@@ -70,7 +70,17 @@ module IsoDoc
                              elem_name)
         ret[:container] = @klass.get_clause_id(node) if opt[:container]
         ret[:value] = stripsemx(lbl)
+        t = asset_title(node) and ret[:title] = t
         ret
+      end
+
+      # Caption of a numbered asset (its <name>, or a modspec requirement's
+      # <title>), semx-wrapped, so that xrefstyle=full can render
+      # "Table 3, caption" the way clauses render "Clause 6, Title". Returns nil
+      # when the asset has no caption, so anchor_xref_full falls back to short.
+      def asset_title(node)
+        n = node.at(ns("./name")) || node.at(ns("./title")) or return nil
+        semx(node, n.children.to_xml, n.name)
       end
 
       include ::IsoDoc::XrefGen::Util

--- a/spec/isodoc/xref_format_spec.rb
+++ b/spec/isodoc/xref_format_spec.rb
@@ -444,6 +444,28 @@ RSpec.describe IsoDoc do
       .to be_xml_equivalent_to output
   end
 
+  it "renders full-style xrefs to captioned assets with their caption" do
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <sections><clause id="A"><title>Clause</title>
+      <p id="P">See <xref target="tab1" style="full"/>, <xref target="fig1" style="full"/>, <xref target="ex1" style="full"/> and <xref target="frm1" style="full"/>.</p>
+      <table id="tab1"><name>Testing tables</name><tbody><tr><td>x</td></tr></tbody></table>
+      <figure id="fig1"><name>Big Cats</name></figure>
+      <example id="ex1"><name>An example</name><p>e</p></example>
+      <formula id="frm1"><stem type="AsciiMath">r</stem></formula>
+      </clause></sections>
+      </iso-standard>
+    INPUT
+    p = Nokogiri::XML(IsoDoc::PresentationXMLConvert.new(presxml_options)
+      .convert("test", input, true))
+      .tap(&:remove_namespaces!).at("//p[@id='P']")
+    # captioned assets (table/figure/example) now expand under full style;
+    # a caption-less asset (formula) keeps the short form
+    expect(p.text.gsub(/\s+/, " ").strip)
+      .to eq "See Table 1, Testing tables, Figure 1, Big Cats, " \
+             "Example, An example and Formula (1)."
+  end
+
   it "cases xrefs" do
     input = <<~INPUT
           <iso-standard xmlns="http://riboseinc.com/isoxml">


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/46

AsciiDoc's `xrefstyle=full` is defined as "signifier, number, and title" for any
captioned reference — it names tables and figures explicitly ("Figure 1, \"Big
Cats\""). metanorma honoured `full` only for clauses/sections (and subclauses, via
metanorma-ribose#522); tables, figures, examples etc. fell back to number-only.
This completes the standard behaviour.

Every numbered asset is built through the base `anchor_struct`
(`lib/isodoc/xref/xref_anchor.rb`), which stored no `:title`, so `anchor_xref_full`
had nothing to append and rendered the short form. One DRY change there —
`asset_title(node)` extracts the asset's `<name>` (or a modspec requirement's
`<title>`), semx-wrapped, and stores it as `:title` — lights up all captioned
assets across all flavours (every flavour override still calls `anchor_struct`).
Caption-less assets return nil and keep the short form, matching AsciiDoc's rule
that full/short apply only to captioned references.

Rendering is unchanged and **unquoted** — "Table 3, caption", consistent with how
clauses render ("Clause 6, Title"). AsciiDoc quotes the title; metanorma's clause
style does not, so quoting stays a separate styling choice.

In scope: table, figure, figure-class, sourcecode, example, ol, dl, box-admonition,
modspec (permission/requirement/recommendation). Out (number-only, no caption):
formula, note, termnote/termexample, paragraph, list-item, deflist-term, bookmark.

## Test plan
- New spec (`xref_format_spec.rb`): `style="full"` xrefs to a table/figure/example
  render "Signifier N, caption"; a caption-less formula stays "Formula (1)".
- Full isodoc suite green: 380 examples, 0 failures, 1 pending (pre-existing).

🤖
