### PR TITLE
Expose bibdata/ext metadata to Liquid templates

### DIFF
--- a/lib/isodoc/metadata_bibdata.rb
+++ b/lib/isodoc/metadata_bibdata.rb
@@ -63,11 +63,59 @@ module IsoDoc
       bib = BibdataConfig.from_xml(
         "<metanorma>#{stripped.root.to_xml}</metanorma>",
       ).bibdata or return nil
-      YAML.safe_load(bib.to_yaml, permitted_classes: [Date, Symbol],
-                                  symbolize_names: true)
+      hash = YAML.safe_load(bib.to_yaml, permitted_classes: [Date, Symbol],
+                                         symbolize_names: true)
+      hash and fold_in_bibdata_ext(hash, stripped)
+      hash
     rescue StandardError => e
       warn "Failed to parse bibdata for Liquid template use: #{e.message}"
       nil
+    end
+
+    # The Liquid `bibdata` object is built by round-tripping //bibdata through
+    # the Relaton object model, which represents bibliographic-item fields but
+    # not the Metanorma-document extension metadata under bibdata/ext
+    # (coverpage-image, innercoverpage-image, ...). Relaton drops those, so
+    # fold the raw ext subtree back in, using the same serialisation convention
+    # Relaton uses: element text -> :content, attributes -> sibling keys,
+    # repeated elements -> arrays, hyphens -> underscores (as in
+    # schema-version -> schema_version). Relaton-modelled keys win on collision;
+    # :ext is only populated when <ext> is present.
+    def fold_in_bibdata_ext(hash, stripped)
+      ext = stripped.at("//bibdata/ext") or return
+      raw = xml_element_hash(ext)
+      raw.is_a?(Hash) or return
+      modelled = hash[:ext].is_a?(Hash) ? hash[:ext] : {}
+      hash[:ext] = raw.merge(modelled)
+    end
+
+    # Generic Nokogiri element -> nested hash in Relaton's serialisation shape.
+    def xml_element_hash(node)
+      hash = {}
+      node.attribute_nodes.each { |a| hash[ext_hash_key(a.node_name)] = a.value }
+      children = node.element_children
+      if children.empty?
+        text = node.text.strip
+        hash[:content] = text unless text.empty?
+      else
+        children.each do |c|
+          add_ext_child(hash, ext_hash_key(c.node_name), xml_element_hash(c))
+        end
+      end
+      hash
+    end
+
+    def add_ext_child(hash, key, value)
+      if hash.key?(key)
+        hash[key] = [hash[key]] unless hash[key].is_a?(Array)
+        hash[key] << value
+      else
+        hash[key] = value
+      end
+    end
+
+    def ext_hash_key(name)
+      name.tr("-", "_").to_sym
     end
   end
 end

--- a/spec/assets/htmlcover_bibdata.html
+++ b/spec/assets/htmlcover_bibdata.html
@@ -1,3 +1,3 @@
 <p class="coverpage-bibdata">BIBDATA:
 {%- assign doi = bibdata.docidentifier | where: "type", "DOI" | first -%}
-{{ doi.content }}|{{ bibdata.status.stage.content }}|{{ bibdata.docnumber }}|{{ bibdata.ext.doctype.content }}</p>
+{{ doi.content }}|{{ bibdata.status.stage.content }}|{{ bibdata.docnumber }}|{{ bibdata.ext.doctype.content }}|{{ bibdata.ext.coverpage_image.image.src }}</p>

--- a/spec/isodoc/metadata_bibdata_spec.rb
+++ b/spec/isodoc/metadata_bibdata_spec.rb
@@ -88,6 +88,40 @@ RSpec.describe IsoDoc::Metadata do
       .to eq "2222"
   end
 
+  it "folds the raw bibdata/ext subtree into meta[:bibdata][:ext] for Liquid" do
+    input = <<~XML
+      <metanorma xmlns="https://www.metanorma.org/ns/standoc">
+        <bibdata type="standard">
+          <docnumber>24041</docnumber>
+          <status><stage>published</stage></status>
+          <ext>
+            <doctype>standard</doctype>
+            <coverpage-image><image src="cover.png"/></coverpage-image>
+            <innercoverpage-image><image src="a.png"/><image src="b.png"/></innercoverpage-image>
+          </ext>
+        </bibdata>
+      </metanorma>
+    XML
+    ext = info(input)[:bibdata][:ext]
+    # Relaton-modelled field preserved, not clobbered by the raw fold-in
+    expect(ext[:doctype]).to eq({ content: "standard" })
+    # Un-modelled ext elements now reachable; hyphens folded to underscores
+    expect(ext[:coverpage_image]).to eq({ image: { src: "cover.png" } })
+    # Repeated child elements become arrays
+    expect(ext[:innercoverpage_image])
+      .to eq({ image: [{ src: "a.png" }, { src: "b.png" }] })
+  end
+
+  it "does not add meta[:bibdata][:ext] when the document has no ext" do
+    input = <<~XML
+      <metanorma xmlns="https://www.metanorma.org/ns/standoc">
+        <bibdata type="standard"><docnumber>1</docnumber>
+        <status><stage>published</stage></status></bibdata>
+      </metanorma>
+    XML
+    expect(info(input)[:bibdata][:ext]).to be_nil
+  end
+
   it "renders bibdata fields in the HTML cover page through Liquid" do
     FileUtils.rm_f "test.html"
     IsoDoc::HtmlConvert.new(
@@ -100,14 +134,14 @@ RSpec.describe IsoDoc::Metadata do
         <docidentifier type="DOI">10.62973/24-041</docidentifier>
         <docnumber>24041</docnumber>
         <status><stage>published</stage></status>
-        <ext><doctype>standard</doctype></ext>
+        <ext><doctype>standard</doctype><coverpage-image><image src="cover.png"/></coverpage-image></ext>
       </bibdata>
       <sections/>
       </iso-standard>
     INPUT
     html = File.read("test.html")
     expect(html)
-      .to include "BIBDATA:10.62973/24-041|published|24041|standard"
+      .to include "BIBDATA:10.62973/24-041|published|24041|standard|cover.png"
     FileUtils.rm_f "test.html"
   end
 end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/40

The `bibdata` Liquid object (from #816) is built by round-tripping `//bibdata`
through the Relaton object model, which models bibliographic-item fields but not
the Metanorma-document extension metadata under `bibdata/ext` (`coverpage-image`,
`innercoverpage-image`, ...). Relaton drops those, so they were unreachable from
coverpage/boilerplate Liquid templates (surfaced by metanorma-pdfa#40:
`:coverpage-image:` in the pdfa HTML cover).

This folds the raw `bibdata/ext` subtree into `meta[:bibdata][:ext]`, using the
same serialisation convention Relaton uses (element text → `content`, attributes
→ sibling keys, repeated elements → arrays, hyphens → underscores, consistent
with `schema-version` → `schema_version`). Relaton-modelled fields win on
collision; `:ext` is only populated when `<ext>` is present, so ext-less
documents are unchanged.

Templates can now address, e.g.:

    {{ bibdata.ext.coverpage_image.image.src }}

## Test plan
- `spec/isodoc/metadata_bibdata_spec.rb`: new unit test (fold-in, doctype
  preserved, repeated → array), a gate test (no `:ext` when `<ext>` absent), and
  the existing Liquid cover render extended to exercise
  `bibdata.ext.coverpage_image.image.src`.
- Neighbouring metadata specs green; the exact-match bibdata fixture unchanged.

🤖
