### PR TITLE
render generator errormsg in concept and related in boldface

### DIFF
--- a/lib/isodoc/presentation_function/concepts.rb
+++ b/lib/isodoc/presentation_function/concepts.rb
@@ -21,6 +21,9 @@ module IsoDoc
 
     def concept_render(node, defaults)
       opts, render, ref, ret = concept_render_init(node, defaults)
+      # generator-emitted term-resolution failure reports
+      # (metanorma-model-iso#144) render in boldface
+      ret&.xpath(ns(".//errormsg"))&.each { |e| e.name = "strong" }
       ret&.at(ns("./refterm"))&.remove
       ref && opts[:ref] != "false" and render&.next = " "
       concept1_linkmention(ref, render, opts)

--- a/lib/isodoc/presentation_function/designations.rb
+++ b/lib/isodoc/presentation_function/designations.rb
@@ -8,12 +8,17 @@ module IsoDoc
     def related1(node)
       p, ref, orig = related1_prep(node)
       label = @i18n.relatedterms[orig["type"]].upcase
+      err = node.at(ns("./errormsg"))
       ret = if p && ref
               if p.text == ref.text
                 "<em>#{Common::to_xml(ref)}</em>"
               else
                 "<em>#{to_xml(p)}</em> (#{Common::to_xml(ref)})"
               end
+            elsif err
+              # generator-emitted term-resolution failure reports
+              # (metanorma-model-iso#144) render in boldface
+              "<strong>#{to_xml(err.children)}</strong>"
             else "<strong>**RELATED TERM NOT FOUND**</strong>"
             end
       node.children = (l10n("<p><strong>#{label}:</strong> #{ret}</p>"))

--- a/spec/isodoc/concept_spec.rb
+++ b/spec/isodoc/concept_spec.rb
@@ -1150,4 +1150,23 @@ RSpec.describe IsoDoc do
       .at("//xmlns:terms").to_xml))
       .to be_xml_equivalent_to output
   end
+  it "renders generator errormsg in concept in boldface" do
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <preface><foreword id="F">
+      <p id="A"><concept><errormsg>term <tt>blah</tt> not resolved via ID <tt>blah</tt></errormsg></concept></p>
+      </foreword></preface>
+      </iso-standard>
+    INPUT
+    pres_output = IsoDoc::PresentationXMLConvert
+      .new(presxml_options)
+      .convert("test", input, true)
+    xml = Nokogiri::XML(pres_output)
+    xml.remove_namespaces!
+    fmt = xml.at("//fmt-concept//strong")
+    expect(fmt).not_to be_nil
+    expect(fmt.text).to include "not resolved via ID"
+    expect(xml.at("//p[@id = 'A']/concept/errormsg")).not_to be_nil
+    expect(xml.at("//fmt-concept//errormsg")).to be_nil
+  end
 end

--- a/spec/isodoc/terms_designations.spec.rb
+++ b/spec/isodoc/terms_designations.spec.rb
@@ -916,4 +916,27 @@ RSpec.describe IsoDoc do
       .convert("test", pres_output, true)))
       .to be_html5_equivalent_to html
   end
+  it "renders generator errormsg in related in boldface" do
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <sections>
+      <terms id="T"><title>Terms</title>
+      <term id="t1"><preferred><expression><name>paddy</name></expression></preferred>
+      <related type="contrast"><errormsg>term <tt>blah</tt> not resolved via ID <tt>blah</tt></errormsg></related>
+      <definition><verbal-definition><p id="d1">rice</p></verbal-definition></definition>
+      </term>
+      </terms>
+      </sections>
+      </iso-standard>
+    INPUT
+    pres_output = IsoDoc::PresentationXMLConvert
+      .new(presxml_options)
+      .convert("test", input, true)
+    xml = Nokogiri::XML(pres_output)
+    xml.remove_namespaces!
+    fmt = xml.at("//fmt-related//strong[tt]")
+    expect(fmt).not_to be_nil
+    expect(fmt.text).to include "not resolved via ID"
+    expect(xml.at("//related/errormsg")).not_to be_nil
+  end
 end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-standoc/pull/1229

Presentation flattening of the `errormsg` carrier (metanorma-model-iso#144): `concept_render` renames it to `strong` in the fmt duplicate, `related1` renders it boldface ahead of the NOT FOUND fallback; the semantic element is preserved. Rendering is unchanged from the pre-errormsg output.

🤖
