### PR TITLE
degrade gracefully on ol types outside the named-template set

### DIFF
--- a/lib/isodoc/presentation_function/list.rb
+++ b/lib/isodoc/presentation_function/list.rb
@@ -68,6 +68,9 @@ module IsoDoc
 
     def ol_label_format(semx, elem)
       template = ol_label_template(elem)[elem.parent["type"].to_sym]
+      # types outside the template set are not decorated, e.g. xml2rfc v2
+      # format strings passed through as ol/@type by metanorma-ietf
+      template or return semx
       template.sub("%", semx)
     end
 

--- a/spec/isodoc/lists_spec.rb
+++ b/spec/isodoc/lists_spec.rb
@@ -507,6 +507,27 @@ RSpec.describe IsoDoc do
       .to be_html4_equivalent_to word
   end
 
+  it "degrades gracefully on ol types outside the named-template set" do
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <preface>
+      <foreword id="F" displayorder="2">
+      <ol id="A" type="R%d">
+      <li id="L1"><p id="P1">Level 1</p></li>
+      </ol>
+      </foreword></preface>
+      </iso-standard>
+    INPUT
+    pres_output = IsoDoc::PresentationXMLConvert.new({})
+      .convert("test", input, true)
+    xml = Nokogiri::XML(pres_output)
+    xml.remove_namespaces!
+    lbl = xml.at("//ol[@id = 'A']/li/fmt-name")
+    expect(lbl).not_to be_nil
+    expect(lbl.at("./semx[@element = 'autonum']")).not_to be_nil
+    expect(lbl.at(".//span[@class = 'fmt-label-delim']")).to be_nil
+  end
+
   it "processes mixed ordered and unordered lists" do
     input = <<~INPUT
           <iso-standard xmlns="http://riboseinc.com/isoxml">


### PR DESCRIPTION
Closes https://github.com/metanorma/isodoc/issues/832

`ol_label_format` now falls back to the bare `semx` numeral when the template lookup returns nil, instead of crashing on `ol/@type` values outside the five named types (e.g. xml2rfc v2 format strings passed through by metanorma-ietf). Spec added. The local override on the metanorma-ietf #257 QA branch (aa03c93) can be dropped once this is released.

🤖
